### PR TITLE
Outputs to imploement IObject instead of inheriting BHoMObject

### DIFF
--- a/Reflection_oM/Output.cs
+++ b/Reflection_oM/Output.cs
@@ -32,14 +32,14 @@ namespace BH.oM.Reflection
 {
     /***************************************************/
 
-    public class Output<T> : BHoMObject, IOutput
+    public class Output<T> : IObject, IOutput
     {
         public T Item1 { get; set; }
     }
 
     /***************************************************/
 
-    public class Output<T1, T2> : BHoMObject, IOutput
+    public class Output<T1, T2> : IObject, IOutput
     {
         public T1 Item1 { get; set; }
 
@@ -48,7 +48,7 @@ namespace BH.oM.Reflection
 
     /***************************************************/
 
-    public class Output<T1, T2, T3> : BHoMObject, IOutput
+    public class Output<T1, T2, T3> : IObject, IOutput
     {
         public T1 Item1 { get; set; }
 
@@ -59,7 +59,7 @@ namespace BH.oM.Reflection
 
     /***************************************************/
 
-    public class Output<T1, T2, T3, T4> : BHoMObject, IOutput
+    public class Output<T1, T2, T3, T4> : IObject, IOutput
     {
         public T1 Item1 { get; set; }
 
@@ -72,7 +72,7 @@ namespace BH.oM.Reflection
 
     /***************************************************/
 
-    public class Output<T1, T2, T3, T4, T5> : BHoMObject, IOutput
+    public class Output<T1, T2, T3, T4, T5> : IObject, IOutput
     {
         public T1 Item1 { get; set; }
 


### PR DESCRIPTION
Fixes #301

`Output<>` no longer inheriting from BHoMObject, but intead only IObject.

Should not have any affect on the current functionalities of the UI. Reason for change is that initialising BHoMObjects can be a bit slow, while performing iterative algorithms that relies on calling a method that has an `Output<>` as a return type. Som initial testing showed that for a simple distance method, the change made here can make the method run approximately 5 times faster.