### PR TITLE
Structure o m issue267 nodes to own a cartesian coordinate system

### DIFF
--- a/Geometry_oM/CoordinateSystem/Cartesian.cs
+++ b/Geometry_oM/CoordinateSystem/Cartesian.cs
@@ -58,5 +58,14 @@ namespace BH.oM.Geometry.CoordinateSystem
         { }
 
         /***************************************************/
+        /**** Explicit Casting                          ****/
+        /***************************************************/
+
+        public static explicit operator Cartesian(Point point)
+        {
+            return new Cartesian() { Origin = point };
+        }
+
+        /***************************************************/
     }
 }

--- a/Structure_oM/Elements/Node.cs
+++ b/Structure_oM/Elements/Node.cs
@@ -33,7 +33,7 @@ namespace BH.oM.Structure.Elements
         /**** Properties                                ****/
         /***************************************************/
 
-        public Point Position { get; set; } = new Point();
+        public Geometry.CoordinateSystem.Cartesian Coordinates { get; set; } = new Geometry.CoordinateSystem.Cartesian();
 
         public Constraint6DOF Constraint { get; set; } = null;
 
@@ -44,7 +44,14 @@ namespace BH.oM.Structure.Elements
 
         public static explicit operator Node(Point point)
         {
-            return new Node { Position = point };
+            return new Node { Coordinates = new Geometry.CoordinateSystem.Cartesian() { Origin = point } };
+        }
+
+        /***************************************************/
+
+        public static explicit operator Node(Geometry.CoordinateSystem.Cartesian coordinateSystem)
+        {
+            return new Node { Coordinates = coordinateSystem };
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #267 

Changing the Node class in the `Structure_oM` from owning a `Point` to a `CoordinateSystem.Cartesian`.
Name for this property updated from `Position` to `Coordinates`

**Please note that this will invalidate any serialised Node and Bar objects!**


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

#### Changed:

- `Node` class property `Position` renamed to `Coordinates` and type changed from `Point` to `CoordinateSystem.Cartesian` #267 

#### Added:
- Explicit casting from `CoordinateSystem.Cartesian` to `Node`
- Explicit casting from `Point` to `CoordinateSystem.Cartesian`

### Additional comments
<!-- As required -->

Changes made include breaking changes for other toolkits. Please do not merge until dependant PR's are raised and approved