### PR TITLE
Add ElementID properties to Opening and Space

### DIFF
--- a/Environment_oM/Elements/Opening.cs
+++ b/Environment_oM/Elements/Opening.cs
@@ -34,6 +34,8 @@ namespace BH.oM.Environment.Elements
 
         public ICurve OpeningCurve { get; set; } = new PolyCurve();
 
+        public string ElementID { get; set; } = "";
+
         /***************************************************/
     }
 }

--- a/Environment_oM/Elements/Space.cs
+++ b/Environment_oM/Elements/Space.cs
@@ -39,6 +39,8 @@ namespace BH.oM.Environment.Elements
         public double HeatingLoad { get; set; } = 0.0;
         public double CoolingLoad { get; set; } = 0.0;
 
+        public string ElementID { get; set; } = "";
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #396 

Adds `ElementID` property to `Opening` and `Space` in `Environment_oM`.


### Test files
N/A


### Changelog
#### Added
 - Add `ElementID` property to Environmental `Opening`
 - Add `ElementID` property to Environmental `Space`