### PR TITLE
Error 404 - Gas Types not found

### DIFF
--- a/Environment_oM/Enums/Materials/GasType.cs
+++ b/Environment_oM/Enums/Materials/GasType.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
  *
@@ -20,26 +20,14 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BH.oM.Base;
-using BH.oM.Environment.Interface;
-using BH.oM.Environment.Materials;
-
-namespace BH.oM.Environment.Properties
+namespace BH.oM.Environment.Materials
 {
-    public class MaterialPropertiesGas : BHoMObject, IMaterialProperties
+    public enum GasType
     {
-        public GasType GasType { get; set; } = GasType.Undefined;
-        public double Conductivity { get; set; } = 0.0;
-        public string Description { get; set; } = string.Empty;
-        public double SpecificHeat { get; set; } = 0.0;
-        public double Density { get; set; } = 0.0;
-        public double ConvectionCoefficient { get; set; } = 0.0;
-        public double VapourDiffusionFactor { get; set; } = 0.0;
+        Undefined,
+        Air,
+        Argon,
+        Krypton,
+        Xenon,
     }
 }

--- a/Environment_oM/Environment_oM.csproj
+++ b/Environment_oM/Environment_oM.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Enums\Elements\ProfileCategory.cs" />
     <Compile Include="Enums\Elements\ProfileType.cs" />
     <Compile Include="Enums\Elements\SimulationDayType.cs" />
+    <Compile Include="Enums\Materials\GasType.cs" />
     <Compile Include="Enums\Results\ProfileResultType.cs" />
     <Compile Include="Enums\Results\ProfileResultUnits.cs" />
     <Compile Include="Enums\Results\SimulationResultType.cs" />
@@ -98,8 +99,6 @@
       <Name>Geometry_oM</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Enums\Materials\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #404 

Adds gas types as requested.


### Test files
N/A


### Changelog
#### Added
 - Add Gas Type enum and `GasType` property to `MaterialPropertiesGas`


### Additional comments
I enjoyed that this issue was #404 - with missing gas types... gave me a chuckle!