### PR TITLE
FramingElement LocationCurve to ICurve

### DIFF
--- a/Structure_oM/Elements/FramingElement.cs
+++ b/Structure_oM/Elements/FramingElement.cs
@@ -32,7 +32,7 @@ namespace BH.oM.Structure.Elements
         /**** Properties                                ****/
         /***************************************************/
 
-        public Line LocationCurve { get; set; } = null;
+        public ICurve LocationCurve { get; set; } = null;
 
         public IFramingElementProperty Property { get; set; } = null;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #331

<!-- Add short description of what has been fixed -->

Framingelement LocationCurve from Line to ICurve.

@ZiolkowskiJakub FYI, could you have a look into how this affects Revit_Toolkit? This needs to be assessed before merging.

### Test files
<!-- Link to test files to validate the proposed changes -->

Please check that any communication with Revit is not broken!

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

#### Changed:
- FramingElement updated to carry an ICurve instead of a Line

### Additional comments
<!-- As required -->