### PR TITLE
Environment_oM - material updates

### DIFF
--- a/Environment_oM/Enums/Materials/MaterialFunction.cs
+++ b/Environment_oM/Enums/Materials/MaterialFunction.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+namespace BH.oM.Environment.Materials
+{
+    public enum MaterialFunction
+    {
+        Undefined,
+        Aggregate,
+        AirGap,
+        Asphalt,
+        Blind,
+        Board,
+        Brick,
+        Carpet,
+        Concrete,
+        Glass,
+        Insulation,
+        Metal,
+        Plaster,
+        Screed,
+        Tile,
+        Timber,
+    }
+}

--- a/Environment_oM/Enums/Materials/MaterialRoughness.cs
+++ b/Environment_oM/Enums/Materials/MaterialRoughness.cs
@@ -1,12 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
 
-namespace BH.oM.Environment.Enums.Materials
+namespace BH.oM.Environment.Materials
 {
-    class MaterialRoughness
+    public enum MaterialRoughness
     {
+        Undefined,
+        VeryRough,
+        MediumRough,
+        Rough,
+        Smooth,
+        MediumSmooth,
+        VerySmooth,
     }
 }

--- a/Environment_oM/Enums/Materials/MaterialRoughness.cs
+++ b/Environment_oM/Enums/Materials/MaterialRoughness.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Environment.Enums.Materials
+{
+    class MaterialRoughness
+    {
+    }
+}

--- a/Environment_oM/Environment_oM.csproj
+++ b/Environment_oM/Environment_oM.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Enums\Gains\GainType.cs" />
     <Compile Include="Enums\Gains\GainUnit.cs" />
     <Compile Include="Enums\Materials\GasType.cs" />
+    <Compile Include="Enums\Materials\MaterialFunction.cs" />
     <Compile Include="Enums\Properties\SizingMethod.cs" />
     <Compile Include="Enums\Results\ProfileResultType.cs" />
     <Compile Include="Enums\Results\ProfileResultUnits.cs" />

--- a/Environment_oM/Environment_oM.csproj
+++ b/Environment_oM/Environment_oM.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Enums\Gains\GainUnit.cs" />
     <Compile Include="Enums\Materials\GasType.cs" />
     <Compile Include="Enums\Materials\MaterialFunction.cs" />
+    <Compile Include="Enums\Materials\MaterialRoughness.cs" />
     <Compile Include="Enums\Properties\SizingMethod.cs" />
     <Compile Include="Enums\Results\ProfileResultType.cs" />
     <Compile Include="Enums\Results\ProfileResultUnits.cs" />

--- a/Environment_oM/Materials/Material.cs
+++ b/Environment_oM/Materials/Material.cs
@@ -35,6 +35,7 @@ namespace BH.oM.Environment.Materials
     public class Material : BHoMObject, IMaterial
     {
         public MaterialType MaterialType { get; set; } = MaterialType.Undefined;
+        public MaterialFunction MaterialFunction { get; set; } = MaterialFunction.Undefined;
         public double Thickness { get; set; } = 0;
         public IMaterialProperties MaterialProperties { get; set; } = null;
     }

--- a/Environment_oM/Materials/Material.cs
+++ b/Environment_oM/Materials/Material.cs
@@ -36,6 +36,7 @@ namespace BH.oM.Environment.Materials
     {
         public MaterialType MaterialType { get; set; } = MaterialType.Undefined;
         public MaterialFunction MaterialFunction { get; set; } = MaterialFunction.Undefined;
+        public MaterialRoughness Roughness { get; set; } = MaterialRoughness.Undefined;
         public double Thickness { get; set; } = 0;
         public IMaterialProperties MaterialProperties { get; set; } = null;
     }

--- a/Environment_oM/Properties/MaterialPropertiesOpaque.cs
+++ b/Environment_oM/Properties/MaterialPropertiesOpaque.cs
@@ -44,5 +44,6 @@ namespace BH.oM.Environment.Properties
         public double LightReflectanceInternal { get; set; } = 0.0;
         public double EmissivityInternal { get; set; } = 0.0;
         public double EmissivityExternal { get; set; } = 0.0;
+        public bool IgnoreInUValueCalculation { get; set; } = false;
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #390 
Fixes #417 

`IsBlind` has not been added despite being requested in #390 - instead a material function has been added to define what function the material is playing in the overall construction. This is more agnostic and better for the Environment_oM overall.

### Test files
N/A


### Changelog
#### Added
 - Added `MaterialFunction` property to `Material` for Environments
 - Added `MaterialRoughness` property to `Material` for Environments


### Additional comments
While ongoing prototyping is done with materials by @IsakNaslundBh , this work allows a move forward with materials and constructions in TKs being developed within BEnv by @tg359 and the gang.