### PR TITLE
Structure_oM: Closes #449 FEMesh to Inherit IAreaElement interface

### DIFF
--- a/Structure_oM/Elements/FEMesh.cs
+++ b/Structure_oM/Elements/FEMesh.cs
@@ -25,7 +25,7 @@ using BH.oM.Structure.Properties.Surface;
 
 namespace BH.oM.Structure.Elements
 {
-    public class FEMesh : Base.BHoMObject
+    public class FEMesh : Base.BHoMObject, IAreaElement
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #449 

<!-- Add short description of what has been fixed -->
Adds IAreaElement interface to FEMesh object.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EhclvxYWIMhKqDKO5wpiDaMB_DZY42ae63L4paYIyWxinw?e=S3BPXQ

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Area loads can be applied to FEMesh objects.