### PR TITLE
Geometry_oM #453 add initial solid geometry representations

### DIFF
--- a/Geometry_oM/Geometry_oM.csproj
+++ b/Geometry_oM/Geometry_oM.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Solid\Cylinder.cs" />
     <Compile Include="Solid\ISolid.cs" />
     <Compile Include="Solid\Sphere.cs" />
+    <Compile Include="Solid\Torus.cs" />
     <Compile Include="Surface\Extrusion.cs" />
     <Compile Include="Surface\ISurface.cs" />
     <Compile Include="Surface\Loft.cs" />

--- a/Geometry_oM/Geometry_oM.csproj
+++ b/Geometry_oM/Geometry_oM.csproj
@@ -62,6 +62,12 @@
     <Compile Include="Misc\Tolerance.cs" />
     <Compile Include="Misc\TransformMatrix.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Solid\BoundaryRepresentation.cs" />
+    <Compile Include="Solid\Cone.cs" />
+    <Compile Include="Solid\Cuboid.cs" />
+    <Compile Include="Solid\Cylinder.cs" />
+    <Compile Include="Solid\ISolid.cs" />
+    <Compile Include="Solid\Sphere.cs" />
     <Compile Include="Surface\Extrusion.cs" />
     <Compile Include="Surface\ISurface.cs" />
     <Compile Include="Surface\Loft.cs" />

--- a/Geometry_oM/Solid/BoundaryRepresentation.cs
+++ b/Geometry_oM/Solid/BoundaryRepresentation.cs
@@ -28,7 +28,7 @@ using System.Linq;
 
 namespace BH.oM.Geometry
 {
-    [Description("Solid representation through a collection of connected surfaces forming a closed volume")]
+    [Description("Solid representation defined by a collection of connected surfaces forming a closed volume")]
     public class BoundaryRepresentation : ISolid, IImmutable
     {
         /***************************************************/

--- a/Geometry_oM/Solid/BoundaryRepresentation.cs
+++ b/Geometry_oM/Solid/BoundaryRepresentation.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System.ComponentModel;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.oM.Geometry
+{
+    [Description("Solid representation through a collection of connected surfaces forming a closed volume")]
+    public class BoundaryRepresentation : ISolid, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("List of ISurfaces must form a closed volume - checks and guarantees to be performed at conversion")]
+        public ReadOnlyCollection<ISurface> Surfaces { get; }
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public BoundaryRepresentation(IEnumerable<ISurface> surfaces)
+        {
+            Surfaces = new ReadOnlyCollection<ISurface>(surfaces.ToList());
+        }
+
+
+        /***************************************************/
+    }
+}

--- a/Geometry_oM/Solid/Cone.cs
+++ b/Geometry_oM/Solid/Cone.cs
@@ -31,6 +31,7 @@ namespace BH.oM.Geometry
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Point defining the centre of the circular base")]
         public Point Centre { get; set; } = new Point();
 
         public Vector Axis { get; set; } = new Vector { X = 0, Y = 0, Z = 1 };

--- a/Geometry_oM/Solid/Cone.cs
+++ b/Geometry_oM/Solid/Cone.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+namespace BH.oM.Geometry
+{
+    [Description("A solid circular right angled cone")]
+    public class Cone : ISolid
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public Point Centre { get; set; } = new Point();
+
+        public Vector Axis { get; set; } = new Vector { X = 0, Y = 0, Z = 1 };
+
+        public double Radius { get; set; } = 0.0;
+
+        public double Height { get; set; } = 0.0;
+
+        /***************************************************/
+    }
+}

--- a/Geometry_oM/Solid/Cuboid.cs
+++ b/Geometry_oM/Solid/Cuboid.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+namespace BH.oM.Geometry
+{
+    public class Cuboid : ISolid
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public CoordinateSystem.Cartesian CoordinateSystem { get; set; } = new CoordinateSystem.Cartesian();
+
+        [Description("Dimension in the XAxis")]
+        public double Length { get; set; } = 0.0;
+
+        [Description("Dimension in the YAxis")]
+        public double Depth { get; set; } = 0.0;
+
+        [Description("Dimension in the ZAxis")]
+        public double Height { get; set; } = 0.0;
+
+
+        /***************************************************/
+    }
+}

--- a/Geometry_oM/Solid/Cylinder.cs
+++ b/Geometry_oM/Solid/Cylinder.cs
@@ -20,14 +20,18 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System.ComponentModel;
+
 namespace BH.oM.Geometry
 {
+    [Description("A solid circular right angled cylinder")]
     public class Cylinder : ISolid
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Point defining the centre of the circular base")]
         public Point Centre { get; set; } = new Point();
 
         public Vector Axis { get; set; } = new Vector { X = 0, Y = 0, Z = 1 };

--- a/Geometry_oM/Solid/Cylinder.cs
+++ b/Geometry_oM/Solid/Cylinder.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+namespace BH.oM.Geometry
+{
+    public class Cylinder : ISolid
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public Point Centre { get; set; } = new Point();
+
+        public Vector Axis { get; set; } = new Vector { X = 0, Y = 0, Z = 1 };
+
+        public double Radius { get; set; } = 0.0;
+
+        public double Height { get; set; } = 0.0;
+
+        /***************************************************/
+    }
+}

--- a/Geometry_oM/Solid/ISolid.cs
+++ b/Geometry_oM/Solid/ISolid.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+namespace BH.oM.Geometry
+{
+    public interface ISolid : IGeometry
+    {
+    }
+}

--- a/Geometry_oM/Solid/Sphere.cs
+++ b/Geometry_oM/Solid/Sphere.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+namespace BH.oM.Geometry
+{
+    public class Sphere : ISolid
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public Point Centre { get; set; } = new Point();
+
+        public double Radius { get; set; } = 0.0;
+
+        /***************************************************/
+    }
+}

--- a/Geometry_oM/Solid/Torus.cs
+++ b/Geometry_oM/Solid/Torus.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+namespace BH.oM.Geometry
+{
+    [Description("A solid circular ring torus")]
+    public class Torus : ISolid
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public Point Centre { get; set; } = new Point();
+
+        public Vector Axis { get; set; } = new Vector { X = 0, Y = 0, Z = 1 };
+
+        public double RadiusMajor { get; set; } = 0.0;
+
+        public double RadiusMinor { get; set; } = 0.0;
+
+        /***************************************************/
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #453
Closes #454
Closes #455 

<!-- Add short description of what has been fixed -->

Creation of initial Solid Geometry representations in the BH.oM.Geometry namespace. As mentioned in the referenced Issues - this will for the immediate term be for representation in BHoM and translation between external libraries and platforms. Beyond Converts, Engine methods will necessarily be kept to a minimum.  



