### PR TITLE
Reflection_oM: DoNotExposeAttribute

### DIFF
--- a/Reflection_oM/Attributes/UIHiddenAttribute.cs
+++ b/Reflection_oM/Attributes/UIHiddenAttribute.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+
+namespace BH.oM.Reflection.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method |
+                    AttributeTargets.Constructor | 
+                    AttributeTargets.Property |
+                    AttributeTargets.Field)]
+    public class DoNotExposeAttribute : Attribute, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Reason { get; private set; } = "";
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public DoNotExposeAttribute(string reason = "")
+        {
+            Reason = reason;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Reflection_oM/Reflection_oM.csproj
+++ b/Reflection_oM/Reflection_oM.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Attributes\OutputAttribute.cs" />
     <Compile Include="Attributes\ReleasedAttribute.cs" />
     <Compile Include="Attributes\AssemblyUrlAttribute.cs" />
+    <Compile Include="Attributes\UIHiddenAttribute.cs" />
     <Compile Include="Debugging\Event.cs" />
     <Compile Include="Debugging\EventType.cs" />
     <Compile Include="Debugging\Log.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #439 
<!-- Add short description of what has been fixed -->
Create the `DoNotExpose` attribute to allow flagging methods, constructor, fields and properties that we do not want to expose to the UIs.
For method it is pretty intuitive. The constructor target is for things like `Query` objects, or any non-standard object that has a constructor we want to obfuscate. For fields and properties, it can be used together with the `Explode` component, to want what we may want to hide form the UI.

For the name, I started with `UIHiddenAttribute`, moved to `NotExposedAttribute` and settled to `DoNotExpose` inasmuch as it expresses the action (as a `delegate`) passed to the UI logic.

Happy to have thoughts about the above!