### PR TITLE
Issue497-BoundindBoxOperatorNullCheck

### DIFF
--- a/Geometry_oM/Misc/BoundingBox.cs
+++ b/Geometry_oM/Misc/BoundingBox.cs
@@ -41,6 +41,9 @@ namespace BH.oM.Geometry
 
         public static BoundingBox operator +(BoundingBox a, BoundingBox b)
         {
+            if (a == null || b == null)
+                return null;
+
             return new BoundingBox
             {
                 Min = new Point { X = Math.Min(a.Min.X, b.Min.X), Y = Math.Min(a.Min.Y, b.Min.Y), Z = Math.Min(a.Min.Z, b.Min.Z) },
@@ -52,6 +55,9 @@ namespace BH.oM.Geometry
 
         public static BoundingBox operator +(BoundingBox box, Vector v)
         {
+            if (box == null || v == null)
+                return null;
+
             return new BoundingBox { Min = box.Min + v, Max = box.Max + v };
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #497
<!-- Add short description of what has been fixed -->
The UI breaks when the operator is called with null arguments. I will treat it in the UI as well, but even if this may be a little forced, I think it is safer to add null checks here.