### PR TITLE
Geometry_oM-Issue503-CreateIElementParentInterface

### DIFF
--- a/Geometry_oM/Geometry_oM.csproj
+++ b/Geometry_oM/Geometry_oM.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Curve\NurbsCurve.cs" />
     <Compile Include="Curve\PolyCurve.cs" />
     <Compile Include="Curve\Polyline.cs" />
+    <Compile Include="Interface\IElement.cs" />
     <Compile Include="Interface\IGeometry.cs" />
     <Compile Include="Interface\IElement0D.cs" />
     <Compile Include="Interface\IElement1D.cs" />

--- a/Geometry_oM/Interface/IElement.cs
+++ b/Geometry_oM/Interface/IElement.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
@@ -24,7 +24,7 @@ using BH.oM.Base;
 
 namespace BH.oM.Geometry
 {
-    public interface IElement1D : IElement
+    public interface IElement : IObject
     {
     }
 }

--- a/Geometry_oM/Interface/IElement0D.cs
+++ b/Geometry_oM/Interface/IElement0D.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -24,7 +24,7 @@ using BH.oM.Base;
 
 namespace BH.oM.Geometry
 {
-    public interface IElement0D : IObject
+    public interface IElement0D : IElement
     {
     }
 }

--- a/Geometry_oM/Interface/IElement2D.cs
+++ b/Geometry_oM/Interface/IElement2D.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -24,7 +24,7 @@ using BH.oM.Base;
 
 namespace BH.oM.Geometry
 {
-    public interface IElement2D : IObject
+    public interface IElement2D : IElement
     {
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #503 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
No test file needed.

### Changelog
#### Added:
- `IElement` parent interface for `IElement0D`, `IElement1D` and `IElement2D` added to allow the methods work on objects having different number of dimensions