### PR TITLE
Add Room object to Architecture oM

### DIFF
--- a/Architecture_oM/Architecture_oM.csproj
+++ b/Architecture_oM/Architecture_oM.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="Elements\Grid.cs" />
     <Compile Include="Elements\Roof.cs" />
+    <Compile Include="Elements\Room.cs" />
     <Compile Include="Elements\Wall.cs" />
     <Compile Include="Elements\Level.cs" />
     <Compile Include="Elements\Floor.cs" />

--- a/Architecture_oM/Elements/Room.cs
+++ b/Architecture_oM/Elements/Room.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Geometry;
+
+namespace BH.oM.Architecture.Elements
+{
+    public class Room : BHoMObject, IElement1D
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public ICurve Perimeter { get; set; } = null;
+
+        /***************************************************/
+    }
+}


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #389 

### Test files
N/A see files changed


### Additional comments
This adds a basic `Room` object for MEP/Energy modelling with @kayleighhoude to begin the workflows around rooms.

The object will need further expansion later but this is to begin prototyping up the workflows.