### PR TITLE
Environment_oM: Add Climate objects

### DIFF
--- a/Environment_oM/Climate/IClimateObject.cs
+++ b/Environment_oM/Climate/IClimateObject.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+
+using BH.oM.Environment.Fragments;
+
+namespace BH.oM.Environment
+{
+    public interface IClimateObject : IEnvironmentObject, IBHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+
+        /***************************************************/
+    }
+}

--- a/Environment_oM/Climate/Location.cs
+++ b/Environment_oM/Climate/Location.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+
+using BH.oM.Environment.Fragments;
+
+namespace BH.oM.Environment.Climate
+{
+    public class Location : BHoMObject, IClimateObject
+    {
+        public double Latitude { get; set; } = 0;
+        public double Longitude { get; set; } = 0;
+        public double Elevation { get; set; } = 0;
+        public double UtcOffset { get; set; } = 0;
+    }
+}

--- a/Environment_oM/Climate/SpaceTime.cs
+++ b/Environment_oM/Climate/SpaceTime.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+
+using BH.oM.Environment.Fragments;
+
+namespace BH.oM.Environment.Climate
+{
+    public class SpaceTime : BHoMObject, IClimateObject
+    {
+        public Location Location { get; set; } = new Location();
+        public int Year { get; set; } = 1900;
+        public int Month { get; set; } = 1;
+        public int Day { get; set; } = 1;
+        public int Hour { get; set; } = 0;
+        public int Minute { get; set; } = 0;
+        public int Second { get; set; } = 0;
+        public int Millisecond { get; set; } = 0;
+    }
+}

--- a/Environment_oM/Climate/Sun.cs
+++ b/Environment_oM/Climate/Sun.cs
@@ -32,7 +32,7 @@ using BH.oM.Environment.Fragments;
 
 namespace BH.oM.Environment.Climate
 {
-    public class SunPosition : BHoMObject, IClimateObject
+    public class Sun : BHoMObject, IClimateObject
     {
         public double Azimuth { get; set; } = 0.0;
         public double Altitude { get; set; } = 0.0;

--- a/Environment_oM/Climate/SunPosition.cs
+++ b/Environment_oM/Climate/SunPosition.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+
+using BH.oM.Environment.Fragments;
+
+namespace BH.oM.Environment.Climate
+{
+    public class SunPosition : BHoMObject, IClimateObject
+    {
+        public double Azimuth { get; set; } = 0.0;
+        public double Altitude { get; set; } = 0.0;
+    }
+}

--- a/Environment_oM/Environment_oM.csproj
+++ b/Environment_oM/Environment_oM.csproj
@@ -41,6 +41,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Climate\IClimateObject.cs" />
+    <Compile Include="Climate\SunPosition.cs" />
     <Compile Include="Elements\Building.cs" />
     <Compile Include="Elements\Edge.cs" />
     <Compile Include="Elements\Enums\BuildingType.cs" />

--- a/Environment_oM/Environment_oM.csproj
+++ b/Environment_oM/Environment_oM.csproj
@@ -42,6 +42,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Climate\IClimateObject.cs" />
+    <Compile Include="Climate\Location.cs" />
+    <Compile Include="Climate\SpaceTime.cs" />
     <Compile Include="Climate\SunPosition.cs" />
     <Compile Include="Elements\Building.cs" />
     <Compile Include="Elements\Edge.cs" />

--- a/Environment_oM/Environment_oM.csproj
+++ b/Environment_oM/Environment_oM.csproj
@@ -44,7 +44,7 @@
     <Compile Include="Climate\IClimateObject.cs" />
     <Compile Include="Climate\Location.cs" />
     <Compile Include="Climate\SpaceTime.cs" />
-    <Compile Include="Climate\SunPosition.cs" />
+    <Compile Include="Climate\Sun.cs" />
     <Compile Include="Elements\Building.cs" />
     <Compile Include="Elements\Edge.cs" />
     <Compile Include="Elements\Enums\BuildingType.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #542 


### Test files
N/A


### Changelog
 - Added SpaceTime Climate object
 - Added Location Climate object
 - Added Sun Climate object
 - Added `Climate` to `BH.oM.Environment` namespace


### Additional comments
This begins the work of centralising some of our climate objects which may be useful in toolkits such as the @BHoM/climateemergency_toolkit , etc.