### PR TITLE
Migrate Grids and Levels from Architecture to Geometry.SettingOut

### DIFF
--- a/Architecture_oM/Elements/Grid.cs
+++ b/Architecture_oM/Elements/Grid.cs
@@ -22,9 +22,11 @@
 
 using BH.oM.Base;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.oM.Architecture.Elements
 {
+    [Deprecated("2.4", "Superseded by BH.oM.Geometry.SettingOut.Grid")]
     public class Grid : BHoMObject, IElement1D
     {
         /***************************************************/

--- a/Architecture_oM/Elements/Level.cs
+++ b/Architecture_oM/Elements/Level.cs
@@ -21,9 +21,11 @@
  */
 
 using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.oM.Architecture.Elements
 {
+    [Deprecated("2.4", "Superseded by BH.oM.Geometry.SettingOut.Level")]
     public class Level : BHoMObject
     {
         /***************************************************/

--- a/Geometry_oM/Geometry_oM.csproj
+++ b/Geometry_oM/Geometry_oM.csproj
@@ -63,6 +63,8 @@
     <Compile Include="Misc\Tolerance.cs" />
     <Compile Include="Misc\TransformMatrix.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SettingOut\Grid.cs" />
+    <Compile Include="SettingOut\Level.cs" />
     <Compile Include="ShapeProfiles\AngleProfile.cs" />
     <Compile Include="ShapeProfiles\BoxProfile.cs" />
     <Compile Include="ShapeProfiles\ChannelProfile.cs" />

--- a/Geometry_oM/SettingOut/Grid.cs
+++ b/Geometry_oM/SettingOut/Grid.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+
+namespace BH.oM.Geometry.SettingOut
+{
+    public class Grid : BHoMObject, IElement1D
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public ICurve Curve { get; set; } = null;
+
+
+        /***************************************************/
+    }
+}

--- a/Geometry_oM/SettingOut/Level.cs
+++ b/Geometry_oM/SettingOut/Level.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+
+namespace BH.oM.Geometry.SettingOut
+{
+    public class Level : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public double Elevation { get; set; } = 0.0;
+
+
+        /***************************************************/
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #536 

<!-- Add short description of what has been fixed -->
`BH.oM.Architecture.Elements.Grid` and `Level` deprecated.
`Grid` and `Level` added to `BH.oM.Geometry.SettingOut`



