### PR TITLE
BHoM: Fragments to be `IObject` instead of `IBHoMObject`

### DIFF
--- a/BHoM/Interface/IBHoMFragment.cs
+++ b/BHoM/Interface/IBHoMFragment.cs
@@ -22,7 +22,7 @@
 
 namespace BH.oM.Base
 {
-    public interface IBHoMFragment : IBHoMObject
+    public interface IBHoMFragment : IObject
     {
 
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR

Closes #563 

As agreed with @adecler, @al-fisher which asked me to action this (also, see discussion in https://github.com/BHoM/BHoM/issues/537):
changed IBHoMFragment to inherit IObject instead of IBHoMObject.

This allows to implement "lighter" fragments in all cases where the BHoMObject properties are not needed.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Changed IBHoMFragment to implement IObject instead of IBHoMObject.