### PR TITLE
Fragments in BHoMObject now stored in a FragmentSet instead of in a List

### DIFF
--- a/BHoM/BHoM.csproj
+++ b/BHoM/BHoM.csproj
@@ -61,6 +61,7 @@
     <Compile Include="CustomObject.cs" />
     <Compile Include="CRUD\CrudConfig.cs" />
     <Compile Include="CRUD\Enums\PushActionType.cs" />
+    <Compile Include="FragmentSet.cs" />
     <Compile Include="Interface\IBHoMFragment.cs" />
     <Compile Include="Interface\IBHoMGroup.cs" />
     <Compile Include="Interface\IObject.cs" />

--- a/BHoM/BHoMObject.cs
+++ b/BHoM/BHoMObject.cs
@@ -35,7 +35,7 @@ namespace BH.oM.Base
 
         public string Name { get; set; } = "";
 
-        public FragmentSet<IBHoMFragment> Fragments { get; set; } = new FragmentSet<IBHoMFragment>();
+        public FragmentSet Fragments { get; set; } = new FragmentSet();
 
         public HashSet<string> Tags { get; set; } = new HashSet<string>();
 

--- a/BHoM/BHoMObject.cs
+++ b/BHoM/BHoMObject.cs
@@ -35,7 +35,7 @@ namespace BH.oM.Base
 
         public string Name { get; set; } = "";
 
-        public List<IBHoMFragment> Fragments { get; set; } = new List<IBHoMFragment>();
+        public FragmentSet<IBHoMFragment> Fragments { get; set; } = new FragmentSet<IBHoMFragment>();
 
         public HashSet<string> Tags { get; set; } = new HashSet<string>();
 

--- a/BHoM/FragmentSet.cs
+++ b/BHoM/FragmentSet.cs
@@ -1,6 +1,6 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -21,22 +21,15 @@
  */
 
 using System;
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace BH.oM.Base
 {
-    public interface IBHoMObject : IObject
+    public class FragmentSet<T> : KeyedCollection<Type, T> where T : IBHoMFragment
     {
-        Guid BHoM_Guid { get; set; }
-
-        string Name { get; set; }
-
-        FragmentSet<IBHoMFragment> Fragments { get; set; }
-
-        HashSet<string> Tags { get; set; }
-
-        Dictionary<string, object> CustomData { get; set; }
-
-        IBHoMObject GetShallowClone(bool newGuid = false);
+        protected override Type GetKeyForItem(T item)
+        {
+            return item.GetType();
+        }
     }
 }

--- a/BHoM/FragmentSet.cs
+++ b/BHoM/FragmentSet.cs
@@ -25,9 +25,9 @@ using System.Collections.ObjectModel;
 
 namespace BH.oM.Base
 {
-    public class FragmentSet<T> : KeyedCollection<Type, T> where T : IBHoMFragment
+    public class FragmentSet : KeyedCollection<Type, IBHoMFragment>
     {
-        protected override Type GetKeyForItem(T item)
+        protected override Type GetKeyForItem(IBHoMFragment item)
         {
             return item.GetType();
         }

--- a/BHoM/FragmentSet.cs
+++ b/BHoM/FragmentSet.cs
@@ -40,12 +40,12 @@ namespace BH.oM.Base
 
         public bool AddOrReplace(IBHoMFragment fragment) // Slower than Add() or SetItem(), but easier to use.
         {
-            int idx = this.Dictionary.Keys.ToList().IndexOf(fragment.GetType());
+            int? idx = this.Dictionary?.Keys.ToList().IndexOf(fragment.GetType());
 
-            if (idx == -1)
+            if (idx == null || idx == -1)
                 base.Add(fragment);
             else
-                base.SetItem(idx, fragment);
+                base.SetItem((int)idx, fragment);
             return true;
         }
 

--- a/BHoM/FragmentSet.cs
+++ b/BHoM/FragmentSet.cs
@@ -21,12 +21,34 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace BH.oM.Base
 {
     public class FragmentSet : KeyedCollection<Type, IBHoMFragment>
     {
+        public FragmentSet()
+        {
+        }
+
+        public FragmentSet(FragmentSet fragmentSet)
+        {
+            fragmentSet.Dictionary.Values.ToList().ForEach(v => this.Add(v));
+        }
+
+        public bool AddOrReplace(IBHoMFragment fragment) // Slower than Add() or SetItem(), but easier to use.
+        {
+            int idx = this.Dictionary.Keys.ToList().IndexOf(fragment.GetType());
+
+            if (idx == -1)
+                base.Add(fragment);
+            else
+                base.SetItem(idx, fragment);
+            return true;
+        }
+
         protected override Type GetKeyForItem(IBHoMFragment item)
         {
             return item.GetType();

--- a/BHoM/Interface/IBHoMObject.cs
+++ b/BHoM/Interface/IBHoMObject.cs
@@ -31,7 +31,7 @@ namespace BH.oM.Base
 
         string Name { get; set; }
 
-        FragmentSet<IBHoMFragment> Fragments { get; set; }
+        FragmentSet Fragments { get; set; }
 
         HashSet<string> Tags { get; set; }
 

--- a/Diffing_oM/HashFragment.cs
+++ b/Diffing_oM/HashFragment.cs
@@ -56,7 +56,7 @@ namespace BH.oM.Diffing
 
         public string Name { get; set; } = "";
 
-        public FragmentSet<IBHoMFragment> Fragments { get; set; } = new FragmentSet<IBHoMFragment>();
+        public FragmentSet Fragments { get; set; } = new FragmentSet();
 
         public HashSet<string> Tags { get; set; } = new HashSet<string>();
 

--- a/Diffing_oM/HashFragment.cs
+++ b/Diffing_oM/HashFragment.cs
@@ -56,7 +56,7 @@ namespace BH.oM.Diffing
 
         public string Name { get; set; } = "";
 
-        public List<IBHoMFragment> Fragments { get; set; } = new List<IBHoMFragment>();
+        public FragmentSet<IBHoMFragment> Fragments { get; set; } = new FragmentSet<IBHoMFragment>();
 
         public HashSet<string> Tags { get; set; } = new HashSet<string>();
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #573 
See also the discussion in #538 (Closes #538).

##### 1. Added the `FragmentSet` class that inherits from `KeyedCollection` to store the Fragments.
The FragmentSet class allows only `IBHoMFragment` types to be stored in the set (`where T : IBHoMFragment` ). 
The set therefore can include only one type of the same Fragment.

The FragmentSet has a method `GetKeyForItem` which returns the `Type` for a specific Fragment, that is the key of the collection. That is the only method that absolutely must be overridden, because without it the KeyedCollection cannot extract the keys from the items. See https://docs.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.keyedcollection-2?view=netframework-4.8

##### 2. Modified Fragments property to be `KeyedCollection<Type, IBHoMFragment>` instead of `List<IBHoMFragment>`

This has several effects:
- Compliance: Fragments now actually reflect their intended nature of an [Entity Component System](https://en.wikipedia.org/wiki/Entity_component_system)
- Safety/compliance: you cannot store more than one Fragment type per object, as originally intended
- Ease of use: no need for convoluted method to extract/append a specific Fragment to a BHoMObject
- Performance: lookup cost is lower as there is no need to check that the Fragment you are `get`ting is the only one in the collection for that Type. See also [profiling versus other collections](https://github.com/BHoM/BHoM/issues/538#issuecomment-521878391).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added the `FragmentSet` class that inherits from `KeyedCollection` to store the Fragments.
- Modified Fragments to be `KeyedCollection<Type, IBHoMFragment>` instead of `List<IBHoMFragment>` in IBHoMObject interface and BHoMObject class

### Additional notes
This change will require modifications in all Toolkits that implement Fragments.
I will open a separate issue for that. This one should be merged together with those changes.
