### PR TITLE
Geometry_oM: Extension of definition of NurbsSurface to handle trims

### DIFF
--- a/Architecture_oM/Elements/Floor.cs
+++ b/Architecture_oM/Elements/Floor.cs
@@ -40,7 +40,7 @@ namespace BH.oM.Architecture.Elements
         /***************************************************/
 
         public Object2DProperties Properties { get; set; } = new Object2DProperties();
-        public ISurface Surface { get; set; } = new NurbsSurface();
+        public ISurface Surface { get; set; } = new PlanarSurface();
 
         /***************************************************/
     }

--- a/Architecture_oM/Elements/Wall.cs
+++ b/Architecture_oM/Elements/Wall.cs
@@ -37,7 +37,7 @@ namespace BH.oM.Architecture.Elements
         /***************************************************/
 
         public Object2DProperties Properties { get; set; } = new Object2DProperties();
-        public ISurface Surface { get; set; } = new NurbsSurface();
+        public ISurface Surface { get; set; } = new PlanarSurface();
 
         /***************************************************/
     }

--- a/Geometry_oM/Geometry_oM.csproj
+++ b/Geometry_oM/Geometry_oM.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Misc\BoundingBox.cs" />
     <Compile Include="Misc\CompositeGeometry.cs" />
     <Compile Include="Misc\Quaternion.cs" />
+    <Compile Include="Misc\SurfaceTrim.cs" />
     <Compile Include="Misc\Tolerance.cs" />
     <Compile Include="Misc\TransformMatrix.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Geometry_oM/Misc/SurfaceTrim.cs
+++ b/Geometry_oM/Misc/SurfaceTrim.cs
@@ -21,23 +21,30 @@
  */
 
 using BH.oM.Base;
-using BH.oM.Geometry;
-using BH.oM.Common.Properties;
-using BH.oM.Common.Interface;
+using System.Collections.Generic;
 
-using BH.oM.Reflection.Attributes;
-
-namespace BH.oM.Architecture.Elements
+namespace BH.oM.Geometry
 {
-    [Deprecated("2.3", "Replaced by BH.oM.Physical.Elements.Roof as part of migration to combined physical namespace")]
-    public class Roof : BHoMObject, IObject2D
+    public class SurfaceTrim : IGeometry, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        public Object2DProperties Properties { get; set; } = new Object2DProperties();
-        public ISurface Surface { get; set; } = new PlanarSurface();
+        public ICurve Curve3d { get; }
+
+        public ICurve Curve2d { get; }
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public SurfaceTrim(ICurve curve3d, ICurve curve2d)
+        {
+            Curve3d = curve3d;
+            Curve2d = curve2d;
+        }
 
         /***************************************************/
     }

--- a/Geometry_oM/Surface/NurbsSurface.cs
+++ b/Geometry_oM/Surface/NurbsSurface.cs
@@ -37,7 +37,19 @@ namespace BH.oM.Geometry
         public List<double> UKnots { get; set; } = new List<double>();
 
         public List<double> VKnots { get; set; } = new List<double>();
-        
+
+        public int UDegree;
+
+        public int VDegree;
+
+        public List<ICurve> ExternalBoundaries3d { get; set; } = new List<ICurve>();
+
+        public List<ICurve> ExternalBoundaries2d { get; set; } = new List<ICurve>();
+
+        public List<ICurve> InternalBoundaries3d { get; set; } = new List<ICurve>();
+
+        public List<ICurve> InternalBoundaries2d { get; set; } = new List<ICurve>();
+
         /***************************************************/
     }
 }

--- a/Geometry_oM/Surface/NurbsSurface.cs
+++ b/Geometry_oM/Surface/NurbsSurface.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -22,6 +22,8 @@
 
 using BH.oM.Base;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace BH.oM.Geometry
 {
@@ -31,25 +33,38 @@ namespace BH.oM.Geometry
         /**** Properties                                ****/
         /***************************************************/
 
-        public List<Point> ControlPoints { get; set; } = new List<Point>();
+        public ReadOnlyCollection<Point> ControlPoints { get; }
 
-        public List<double> Weights { get; set; } = new List<double>();
+        public ReadOnlyCollection<double> Weights { get; }
 
-        public List<double> UKnots { get; set; } = new List<double>();
+        public ReadOnlyCollection<double> UKnots { get; }
 
-        public List<double> VKnots { get; set; } = new List<double>();
+        public ReadOnlyCollection<double> VKnots { get; }
 
-        public int UDegree;
+        public int UDegree { get; }
 
-        public int VDegree;
+        public int VDegree { get; }
 
-        public List<ICurve> ExternalBoundaries3d { get; set; } = new List<ICurve>();
+        public ReadOnlyCollection<SurfaceTrim> InnerTrims { get; }
 
-        public List<ICurve> ExternalBoundaries2d { get; set; } = new List<ICurve>();
+        public ReadOnlyCollection<SurfaceTrim> OuterTrims { get; }
 
-        public List<ICurve> InternalBoundaries3d { get; set; } = new List<ICurve>();
 
-        public List<ICurve> InternalBoundaries2d { get; set; } = new List<ICurve>();
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public NurbsSurface(IEnumerable<Point> controlPoints, IEnumerable<double> weights, IEnumerable<double> uKnots, IEnumerable<double> vKnots, int uDegree, int vDegree, IEnumerable<SurfaceTrim> innerTrims, IEnumerable<SurfaceTrim> outerTrims)
+        {
+            ControlPoints = new ReadOnlyCollection<Point>(controlPoints.ToList());
+            Weights = new ReadOnlyCollection<double>(weights.ToList());
+            UKnots = new ReadOnlyCollection<double>(uKnots.ToList());
+            VKnots = new ReadOnlyCollection<double>(vKnots.ToList());
+            UDegree = uDegree;
+            VDegree = vDegree;
+            InnerTrims = new ReadOnlyCollection<SurfaceTrim>(innerTrims.ToList());
+            OuterTrims = new ReadOnlyCollection<SurfaceTrim>(outerTrims.ToList());
+        }
 
         /***************************************************/
     }

--- a/Geometry_oM/Surface/NurbsSurface.cs
+++ b/Geometry_oM/Surface/NurbsSurface.cs
@@ -20,11 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System.Collections.Generic;
 
 namespace BH.oM.Geometry
 {
-    public class NurbsSurface : ISurface
+    public class NurbsSurface : ISurface, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #425

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test files are located on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%2FGeometry%5FoM%2DIssue425%2DCreationOfTrimmedNurbsSurfaceDefinition). To run it, please switch to the branches related to the following PRs:
- [#603 ](https://github.com/BHoM/BHoM/pull/603)
- [#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)
- [#122](https://github.com/BHoM/Rhinoceros_Toolkit/pull/122)
- [#435](https://github.com/BHoM/Grasshopper_Toolkit/pull/435)
- [#435](https://github.com/BHoM/Revit_Toolkit/pull/435)
- [#183](https://github.com/BHoM/Dynamo_Toolkit/pull/183)

The error in Rhino -> BHoM -> Rhino convert error in the test file is caused by the bug in Cone convert logged [here](https://github.com/BHoM/Rhinoceros_Toolkit/issues/121).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.oM.Geometry.SurfaceTrim` class has been added
- `BH.oM.Geometry.NurbsSurface` definition has been extended with additional properties in order to handle trims + `IImmutable` interface has been implemented

### Additional comments
This PR has been in progress for quite some time already - finally it got to the point where it makes sense to review it. In general, the definition of `NurbsSurface` has been extended in order to handle trims - I decided not to create a separate class for it because:
1. `PlanarSurface` contains the information about its outlines, therefore it seems logical to align `NurbsSurface` to it.
2. An unbounded nurbs surface will not often appear in AEC applications, and even if it will, the instance can always carry no trims.
3. Creation of another class would cause even more challenges on converts.

Both 3D curves and their representations in the UV coordinates of the surfaces are stored in `NurbsSurface`. The reason for that is the fact that even Rhino does not always handle conversion correctly ([Surface.Pullback](https://developer.rhino3d.com/api/RhinoCommon/html/M_Rhino_Geometry_Surface_Pullback.htm) and [Surface.Pushup](https://developer.rhino3d.com/api/RhinoCommon/html/M_Rhino_Geometry_Surface_Pushup.htm) methods often fail on seams). Division into outer and inner trims could possibly be avoided, but I believe it will make the code easier to apply. Pairs of 2d and 3d trim curves have been wrapped into `SurfaceTrim` class.

Additionally, the `NurbsSurface` class has been extended by two int properties: `UDegree` and `VDegree`. This is caused by the fact that querying the degree of a nurbs surface based on its knot vector is not always possible (see [#1297](https://github.com/BHoM/BHoM_Engine/issues/1297)).