### PR TITLE
Structure_oM: MeshFaceId correctly assigned in constructor for MeshElementResults

### DIFF
--- a/Structure_oM/Results/Mesh/MeshElementResult.cs
+++ b/Structure_oM/Results/Mesh/MeshElementResult.cs
@@ -43,16 +43,16 @@ namespace BH.oM.Structure.Results
 
         public IComparable ResultCase { get; set; } = "";
 
-        public double TimeStep { get; set; } = 0.0;
+        public double TimeStep { get; } = 0.0;
 
-        public MeshResultLayer MeshResultLayer { get; set; }
+        public MeshResultLayer MeshResultLayer { get; }
 
-        public double LayerPosition { get; set; }
+        public double LayerPosition { get; }
 
-        public MeshResultSmoothingType Smoothing { get; set; }
+        public MeshResultSmoothingType Smoothing { get; }
 
         [Description("Vector basis required in order to report results in a particular direction, for example, for anisotropic materials")]
-        public Basis Orientation { get; set; } = Basis.XY;
+        public Basis Orientation { get; } = Basis.XY;
 
 
         /***************************************************/
@@ -71,7 +71,7 @@ namespace BH.oM.Structure.Results
         {
             ObjectId = objectId;
             NodeId = nodeId;
-            MeshFaceId = MeshFaceId;
+            MeshFaceId = meshFaceId;
             ResultCase = resultCase;
             TimeStep = timeStep;
             MeshResultLayer = meshResultLayer;

--- a/Structure_oM/Results/Mesh/MeshElementResult.cs
+++ b/Structure_oM/Results/Mesh/MeshElementResult.cs
@@ -41,7 +41,7 @@ namespace BH.oM.Structure.Results
 
         public IComparable MeshFaceId { get; } = "";
 
-        public IComparable ResultCase { get; set; } = "";
+        public IComparable ResultCase { get; } = "";
 
         public double TimeStep { get; } = 0.0;
 

--- a/Structure_oM/Results/Mesh/MeshResult.cs
+++ b/Structure_oM/Results/Mesh/MeshResult.cs
@@ -47,7 +47,7 @@ namespace BH.oM.Structure.Results
         [Description("Position within the element thickness that result is extracted from, normalised to 1. 0 = lower surface, 0.5 = middle, 1 = top surface")]
         public double LayerPosition { get; }
 
-        public MeshResultSmoothingType Smoothing { get;  }
+        public MeshResultSmoothingType Smoothing { get; }
 
         public ReadOnlyCollection<MeshElementResult> Results { get; }
 

--- a/Structure_oM/Results/Mesh/MeshResult.cs
+++ b/Structure_oM/Results/Mesh/MeshResult.cs
@@ -42,7 +42,7 @@ namespace BH.oM.Structure.Results
 
         public double TimeStep { get; }
 
-        public MeshResultLayer Layer { get;} 
+        public MeshResultLayer Layer { get; } 
 
         [Description("Position within the element thickness that result is extracted from, normalised to 1. 0 = lower surface, 0.5 = middle, 1 = top surface")]
         public double LayerPosition { get; }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #618 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/Issue-227-UpdateResultRequests?csf=1&e=S9Vtsn

Note, testfile requires https://github.com/BHoM/ETABS_Toolkit/tree/Etabs_Toolkit-%23227-UpdateResultExtractionToWorkWithNewRequest to work properly


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Bug fixed for meshFaceId being assigned incorrectly
- Removing setters from all parameters in MeshElementResults, making it fully immutable

### Additional comments
<!-- As required -->