### PR TITLE
Structure_oM: Fixing parameter name of MeshResult constructor

### DIFF
--- a/Structure_oM/Results/Mesh/MeshResult.cs
+++ b/Structure_oM/Results/Mesh/MeshResult.cs
@@ -55,12 +55,12 @@ namespace BH.oM.Structure.Results
         /**** Constructors                              ****/
         /***************************************************/
 
-        public MeshResult(IComparable objectId, IComparable resultCase, double timeStep, MeshResultLayer resultLayer, double layerPosition, MeshResultSmoothingType smoothing, ReadOnlyCollection<MeshElementResult> results)
+        public MeshResult(IComparable objectId, IComparable resultCase, double timeStep, MeshResultLayer layer, double layerPosition, MeshResultSmoothingType smoothing, ReadOnlyCollection<MeshElementResult> results)
         {
             ObjectId = objectId;
             ResultCase = resultCase;
             TimeStep = timeStep;
-            Layer = resultLayer;
+            Layer = layer;
             LayerPosition = layerPosition;
             Smoothing = smoothing;
             Results = results;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #639 

<!-- Add short description of what has been fixed -->

Parameter in constructor in MeshResult did not match property name

### Test files
<!-- Link to test files to validate the proposed changes -->

Test that mesh result still can be pulled from Robot and/or Etabs:

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/ETABS_Toolkit/Issue-227-UpdateResultRequests?csf=1&e=2m8egn

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Issues/Issue277-UpdateResultToWorkWithResultRequest?csf=1&e=RhpZLb

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->