### PR TITLE
Structure_oM: Adding Timber, Aluminium and generic sections and materials

### DIFF
--- a/Structure_oM/MaterialFragments/GenericIsotropicMaterial.cs
+++ b/Structure_oM/MaterialFragments/GenericIsotropicMaterial.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System.ComponentModel;
+
+namespace BH.oM.Structure.MaterialFragments
+{
+    [Description("Generic isotropic material to be used for isotropic materials not yet explicitly supported")]
+    public class GenericIsotropicMaterial : BHoMObject, IIsotropic
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public double Density { get; set; }
+
+        public double DampingRatio { get; set; }
+
+        public double PoissonsRatio { get; set; }
+
+        public double ThermalExpansionCoeff { get; set; }
+
+        public double YoungsModulus { get; set; }
+
+        public double EmbodiedCarbon { get; set; }
+
+        /***************************************************/
+
+    }
+}

--- a/Structure_oM/MaterialFragments/GenericOrthotropicMaterial.cs
+++ b/Structure_oM/MaterialFragments/GenericOrthotropicMaterial.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Geometry;
+using System.ComponentModel;
+
+namespace BH.oM.Structure.MaterialFragments
+{
+    [Description("Generic orthotropic material to be used for orthotropic materials not yet explicitly supported")]
+    public class GenericOrthotropicMaterial : BHoMObject, IOrthotropic
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public double Density { get; set; }
+
+        public double DampingRatio { get; set; }
+
+        public Vector PoissonsRatio { get; set; }
+
+        public Vector ThermalExpansionCoeff { get; set; }
+
+        public Vector YoungsModulus { get; set; }
+
+        public Vector ShearModulus { get; set; }
+
+        public double EmbodiedCarbon { get; set; }
+
+        /***************************************************/
+
+    }
+}

--- a/Structure_oM/MaterialFragments/IMaterialFragment.cs
+++ b/Structure_oM/MaterialFragments/IMaterialFragment.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Physical.Materials;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.MaterialFragments
 {
-    public interface IMaterialFragment : IMaterialProperties
+    public interface IMaterialFragment : IBHoMFragment, IMaterialProperties
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Structure_oM/SectionProperties/AluminiumSection.cs
+++ b/Structure_oM/SectionProperties/AluminiumSection.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry.ShapeProfiles;
+using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
@@ -33,109 +34,76 @@ namespace BH.oM.Structure.SectionProperties
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Material of the section")]
         public IMaterialFragment Material { get; set; } = null;
 
         /***************************************************/
         /**** Properties - Section profile              ****/
         /***************************************************/
 
+        [Description("Profile of the section, containing dimensions and section geometry")]
         public IProfile SectionProfile { get; }
-
 
         /***************************************************/
         /**** Properties - Section constants            ****/
         /***************************************************/
 
+        [Description("Gross Area of the cross section")]
+        public double Area { get; }
 
-        /// <summary>
-        /// Gross Area of the cross section
-        /// </summary>
-        public double Area { get; } = 0;
+        [Description("Radius of Gyration about the Y-Axis")]
+        public double Rgy { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Y-Axis
-        /// </summary>
-        public double Rgy { get; } = 0;
+        [Description("Radius of Gyration about the Z-Axis")]
+        public double Rgz { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Z-Axis
-        /// </summary>
-        public double Rgz { get; } = 0;
+        [Description("Torsion Constant")]
+        public double J { get; }
 
-        /// <summary>
-        /// Torsion Constant
-        /// </summary>
-        public double J { get; } = 0;
+        [Description("Moment of Inertia about the Y-Axis")]
+        public double Iy { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Y-Axis
-        /// </summary>
-        public double Iy { get; } = 0;
+        [Description("Moment of Inertia about the Z-Axis")]
+        public double Iz { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Z-Axis
-        /// </summary>
-        public double Iz { get; } = 0;
+        [Description("Warping Constant")]
+        public double Iw { get; }
 
-        /// <summary>
-        /// Warping Constant
-        /// </summary>
-        public double Iw { get; } = 0;
+        [Description("Elastic Modulus of the section about the Y-Axis")]
+        public double Wely { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wely { get; } = 0;
+        [Description("Elastic Modulus of the section about the Z-Axis")]
+        public double Welz { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Welz { get; } = 0;
-        /// <summary>
-        /// Plastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wply { get; } = 0;
+        [Description("Plastic Modulus of the section about the Y-Axis")]
+        public double Wply { get; }
 
-        /// <summary>
-        /// Plastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Wplz { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Z direction
-        /// </summary>
-        public double CentreZ { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Y direction
-        /// </summary>
-        public double CentreY { get; } = 0;
+        [Description("Plastic Modulus of the section about the Z-Axis")]
+        public double Wplz { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to top edge of the section
-        /// </summary>
-        public double Vz { get; } = 0;
+        [Description("Geometric centre of the section in the Z direction")]
+        public double CentreZ { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to bottom edge of the section
-        /// </summary>
-        public double Vpz { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to right edge of the section
-        /// </summary>
-        public double Vy { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to Left edge of the section
-        /// </summary>
-        public double Vpy { get; } = 0;
+        [Description("Geometric centre of the section in the Y direction")]
+        public double CentreY { get; }
 
-        /// <summary>
-        /// Shear Area in the Y direction
-        /// </summary>
-        public double Asy { get; } = 0;
+        [Description("Z Distance from the centroid of the section to top edge of the section")]
+        public double Vz { get; }
 
-        /// <summary>
-        /// Shear Area in the Z direction
-        /// </summary>
-        public double Asz { get; } = 0;
+        [Description("Z Distance from the centroid of the section to bottom edge of the section")]
+        public double Vpz { get; }
+
+        [Description("Y Distance from the centroid of the section to right edge of the section")]
+        public double Vy { get; }
+
+        [Description("Y Distance from the centroid of the section to Left edge of the section")]
+        public double Vpy { get; }
+
+        [Description("Shear Area in the Y direction")]
+        public double Asy { get; }
+
+        [Description("Shear Area in the Z direction")]
+        public double Asz { get; }
 
 
         /***************************************************/

--- a/Structure_oM/SectionProperties/AluminiumSection.cs
+++ b/Structure_oM/SectionProperties/AluminiumSection.cs
@@ -27,7 +27,7 @@ using BH.oM.Geometry.ShapeProfiles;
 namespace BH.oM.Structure.SectionProperties
 {
 
-    public class TimberSection : BHoMObject, IGeometricalSection, IImmutable
+    public class AluminiumSection : BHoMObject, IGeometricalSection, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -143,7 +143,7 @@ namespace BH.oM.Structure.SectionProperties
         /***************************************************/
 
         //Main constructor setting all of the properties of the object
-        public TimberSection(
+        public AluminiumSection(
             IProfile sectionProfile,
 
             double area,

--- a/Structure_oM/SectionProperties/CableSection.cs
+++ b/Structure_oM/SectionProperties/CableSection.cs
@@ -24,6 +24,7 @@
 
 using BH.oM.Base;
 using BH.oM.Structure.MaterialFragments;
+using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
@@ -33,6 +34,7 @@ namespace BH.oM.Structure.SectionProperties
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Material of the section")]
         public IMaterialFragment Material { get; set; } = null;
 
 

--- a/Structure_oM/SectionProperties/ConcreteSection.cs
+++ b/Structure_oM/SectionProperties/ConcreteSection.cs
@@ -31,7 +31,7 @@ using BH.oM.Geometry.ShapeProfiles;
 namespace BH.oM.Structure.SectionProperties
 {
 
-    public class ConcreteSection : BHoMObject, ISectionProperty, IImmutable
+    public class ConcreteSection : BHoMObject, IGeometricalSection, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Structure_oM/SectionProperties/ConcreteSection.cs
+++ b/Structure_oM/SectionProperties/ConcreteSection.cs
@@ -27,6 +27,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry.ShapeProfiles;
+using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
@@ -41,6 +42,7 @@ namespace BH.oM.Structure.SectionProperties
 
         public double MinimumCover { get; }  //TODO: Do we need this property or should it be a BHoM_Engine query?
 
+        [Description("Material of the section")]
         public IMaterialFragment Material { get; set; }
 
 
@@ -48,6 +50,7 @@ namespace BH.oM.Structure.SectionProperties
         /**** Properties - Section dimensions           ****/
         /***************************************************/
 
+        [Description("Profile of the section, containing dimensions and section geometry")]
         public IProfile SectionProfile { get; }
 
 
@@ -55,114 +58,82 @@ namespace BH.oM.Structure.SectionProperties
         /**** Properties - Section constants            ****/
         /***************************************************/
 
-        /// <summary>
-        /// Gross Area of the cross section
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Area { get; } = 0;
 
-        /// <summary>
-        /// Radius of Gyration about the Y-Axis
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Rgy { get; } = 0;
+        [Description("Gross Area of the cross sectio"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Area { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Z-Axis
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Rgz { get; } = 0;
+        [Description("Radius of Gyration about the Y-Axis"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Rgy { get; }
 
-        /// <summary>
-        /// Torsion Constant
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double J { get; } = 0;
+        [Description("Radius of Gyration about the Z-Axis"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Rgz { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Y-Axis
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Iy { get; } = 0;
+        [Description("Torsion Constant"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double J { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Z-Axis
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Iz { get; } = 0;
+        [Description("Moment of Inertia about the Y-Axis"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Iy { get; }
 
-        /// <summary>
-        /// Warping Constant
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Iw { get; } = 0;
+        [Description("Moment of Inertia about the Z-Axis"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Iz { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Y-Axis
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Wely { get; } = 0;
+        [Description("Warping Constant"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Iw { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Z-Axis
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Welz { get; } = 0;
-        /// <summary>
-        /// Plastic Modulus of the section about the Y-Axis
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Wply { get; } = 0;
+        [Description("Elastic Modulus of the section about the Y-Axis"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Wely { get; }
 
-        /// <summary>
-        /// Plastic Modulus of the section about the Z-Axis
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Wplz { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Z direction
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double CentreZ { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Y direction
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double CentreY { get; } = 0;
+        [Description("Elastic Modulus of the section about the Z-Axis"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Welz { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to top edge of the section
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Vz { get; } = 0;
+        [Description("Plastic Modulus of the section about the Y-Axis"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Wply { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to bottom edge of the section
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Vpz { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to right edge of the section
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Vy { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to Left edge of the section
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Vpy { get; } = 0;
+        [Description("Plastic Modulus of the section about the Z-Axis"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Wplz { get; }
 
-        /// <summary>
-        /// Shear Area in the Y direction
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Asy { get; } = 0;
+        [Description("Geometric centre of the section in the Z direction" 
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double CentreZ { get; }
 
-        /// <summary>
-        /// Shear Area in the Z direction
-        /// Uncracked section disregarding the reinforcement.
-        /// </summary>
-        public double Asz { get; } = 0;
+        [Description("Geometric centre of the section in the Y direction" 
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double CentreY { get; }
+
+        [Description("Z Distance from the centroid of the section to top edge of the section"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Vz { get; }
+
+        [Description("Z Distance from the centroid of the section to bottom edge of the section"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Vpz { get; }
+
+        [Description("Y Distance from the centroid of the section to right edge of the section"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Vy { get; }
+
+        [Description("Y Distance from the centroid of the section to Left edge of the section"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Vpy { get; }
+
+        [Description("Shear Area in the Y direction"
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Asy { get; }
+
+        [Description("Shear Area in the Z direction" 
+            + "\n Uncracked section disregarding the reinforcement.")]
+        public double Asz { get; }
 
 
         /***************************************************/

--- a/Structure_oM/SectionProperties/ExplicitSection.cs
+++ b/Structure_oM/SectionProperties/ExplicitSection.cs
@@ -22,9 +22,11 @@
 
 using BH.oM.Base;
 using BH.oM.Structure.MaterialFragments;
+using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
+    [Description("Material agnostic section. Does not own any geometry. Allows explicit setting of all section constants")]
     public class ExplicitSection : BHoMObject, ISectionProperty
     {
 

--- a/Structure_oM/SectionProperties/ExplicitSection.cs
+++ b/Structure_oM/SectionProperties/ExplicitSection.cs
@@ -34,97 +34,65 @@ namespace BH.oM.Structure.SectionProperties
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Material of the section")]
         public IMaterialFragment Material { get; set; } = null;
 
-        /// <summary>
-        /// Gross Area of the cross section
-        /// </summary>
-        public double Area { get; set; } = 0;
+        [Description("Gross Area of the cross section")]
+        public double Area { get; set; }
 
-        /// <summary>
-        /// Radius of Gyration about the Y-Axis
-        /// </summary>
-        public double Rgy { get; set; } = 0;
+        [Description("Radius of Gyration about the Y-Axis")]
+        public double Rgy { get; set; }
 
-        /// <summary>
-        /// Radius of Gyration about the Z-Axis
-        /// </summary>
-        public double Rgz { get; set; } = 0;
+        [Description("Radius of Gyration about the Z-Axis")]
+        public double Rgz { get; set; }
 
-        /// <summary>
-        /// Torsion Constant
-        /// </summary>
-        public double J { get; set; } = 0;
+        [Description("Torsion Constant")]
+        public double J { get; set; }
 
-        /// <summary>
-        /// Moment of Inertia about the Y-Axis
-        /// </summary>
-        public double Iy { get; set; } = 0;
+        [Description("Moment of Inertia about the Y-Axis")]
+        public double Iy { get; set; }
 
-        /// <summary>
-        /// Moment of Inertia about the Z-Axis
-        /// </summary>
-        public double Iz { get; set; } = 0;
+        [Description("Moment of Inertia about the Z-Axis")]
+        public double Iz { get; set; }
 
-        /// <summary>
-        /// Warping Constant
-        /// </summary>
-        public double Iw { get; set; } = 0;
+        [Description("Warping Constant")]
+        public double Iw { get; set; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wely { get; set; } = 0;
+        [Description("Elastic Modulus of the section about the Y-Axis")]
+        public double Wely { get; set; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Welz { get; set; } = 0;
-        /// <summary>
-        /// Plastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wply { get; set; } = 0;
+        [Description("Elastic Modulus of the section about the Z-Axis")]
+        public double Welz { get; set; }
 
-        /// <summary>
-        /// Plastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Wplz { get; set; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Z direction
-        /// </summary>
-        public double CentreZ { get; set; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Y direction
-        /// </summary>
-        public double CentreY { get; set; } = 0;
+        [Description("Plastic Modulus of the section about the Y-Axis")]
+        public double Wply { get; set; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to top edge of the section
-        /// </summary>
-        public double Vz { get; set; } = 0;
+        [Description("Plastic Modulus of the section about the Z-Axis")]
+        public double Wplz { get; set; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to bottom edge of the section
-        /// </summary>
-        public double Vpz { get; set; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to right edge of the section
-        /// </summary>
-        public double Vy { get; set; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to Left edge of the section
-        /// </summary>
-        public double Vpy { get; set; } = 0;
+        [Description("Geometric centre of the section in the Z direction")]
+        public double CentreZ { get; set; }
 
-        /// <summary>
-        /// Shear Area in the Y direction
-        /// </summary>
-        public double Asy { get; set; } = 0;
+        [Description("Geometric centre of the section in the Y direction")]
+        public double CentreY { get; set; }
 
-        /// <summary>
-        /// Shear Area in the Z direction
-        /// </summary>
-        public double Asz { get; set; } = 0;
+        [Description("Z Distance from the centroid of the section to top edge of the section")]
+        public double Vz { get; set; }
+
+        [Description("Z Distance from the centroid of the section to bottom edge of the section")]
+        public double Vpz { get; set; }
+
+        [Description("Y Distance from the centroid of the section to right edge of the section")]
+        public double Vy { get; set; }
+
+        [Description("Y Distance from the centroid of the section to Left edge of the section")]
+        public double Vpy { get; set; }
+
+        [Description("Shear Area in the Y direction")]
+        public double Asy { get; set; }
+
+        [Description("Shear Area in the Z direction")]
+        public double Asz { get; set; }
 
 
         /***************************************************/

--- a/Structure_oM/SectionProperties/GenericSection.cs
+++ b/Structure_oM/SectionProperties/GenericSection.cs
@@ -23,11 +23,12 @@
 using BH.oM.Base;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry.ShapeProfiles;
+using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
-
-    public class TimberSection : BHoMObject, IGeometricalSection, IImmutable
+    [Description("Material agnostic section. To be used for sections of material types not yet explicitily supported.")]
+    public class GenericSection : BHoMObject, IGeometricalSection, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -143,7 +144,7 @@ namespace BH.oM.Structure.SectionProperties
         /***************************************************/
 
         //Main constructor setting all of the properties of the object
-        public TimberSection(
+        public GenericSection(
             IProfile sectionProfile,
 
             double area,

--- a/Structure_oM/SectionProperties/GenericSection.cs
+++ b/Structure_oM/SectionProperties/GenericSection.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
-    [Description("Material agnostic section. To be used for sections of material types not yet explicitily supported.")]
+    [Description("Material agnostic section. To be used for sections of material types not yet explicitly supported.")]
     public class GenericSection : BHoMObject, IGeometricalSection, IImmutable
     {
         /***************************************************/

--- a/Structure_oM/SectionProperties/GenericSection.cs
+++ b/Structure_oM/SectionProperties/GenericSection.cs
@@ -34,109 +34,76 @@ namespace BH.oM.Structure.SectionProperties
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Material of the section")]
         public IMaterialFragment Material { get; set; } = null;
 
         /***************************************************/
         /**** Properties - Section profile              ****/
         /***************************************************/
 
+        [Description("Profile of the section, containing dimensions and section geometry")]
         public IProfile SectionProfile { get; }
-
 
         /***************************************************/
         /**** Properties - Section constants            ****/
         /***************************************************/
 
+        [Description("Gross Area of the cross section")]
+        public double Area { get; }
 
-        /// <summary>
-        /// Gross Area of the cross section
-        /// </summary>
-        public double Area { get; } = 0;
+        [Description("Radius of Gyration about the Y-Axis")]
+        public double Rgy { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Y-Axis
-        /// </summary>
-        public double Rgy { get; } = 0;
+        [Description("Radius of Gyration about the Z-Axis")]
+        public double Rgz { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Z-Axis
-        /// </summary>
-        public double Rgz { get; } = 0;
+        [Description("Torsion Constant")]
+        public double J { get; }
 
-        /// <summary>
-        /// Torsion Constant
-        /// </summary>
-        public double J { get; } = 0;
+        [Description("Moment of Inertia about the Y-Axis")]
+        public double Iy { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Y-Axis
-        /// </summary>
-        public double Iy { get; } = 0;
+        [Description("Moment of Inertia about the Z-Axis")]
+        public double Iz { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Z-Axis
-        /// </summary>
-        public double Iz { get; } = 0;
+        [Description("Warping Constant")]
+        public double Iw { get; }
 
-        /// <summary>
-        /// Warping Constant
-        /// </summary>
-        public double Iw { get; } = 0;
+        [Description("Elastic Modulus of the section about the Y-Axis")]
+        public double Wely { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wely { get; } = 0;
+        [Description("Elastic Modulus of the section about the Z-Axis")]
+        public double Welz { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Welz { get; } = 0;
-        /// <summary>
-        /// Plastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wply { get; } = 0;
+        [Description("Plastic Modulus of the section about the Y-Axis")]
+        public double Wply { get; }
 
-        /// <summary>
-        /// Plastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Wplz { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Z direction
-        /// </summary>
-        public double CentreZ { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Y direction
-        /// </summary>
-        public double CentreY { get; } = 0;
+        [Description("Plastic Modulus of the section about the Z-Axis")]
+        public double Wplz { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to top edge of the section
-        /// </summary>
-        public double Vz { get; } = 0;
+        [Description("Geometric centre of the section in the Z direction")]
+        public double CentreZ { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to bottom edge of the section
-        /// </summary>
-        public double Vpz { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to right edge of the section
-        /// </summary>
-        public double Vy { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to Left edge of the section
-        /// </summary>
-        public double Vpy { get; } = 0;
+        [Description("Geometric centre of the section in the Y direction")]
+        public double CentreY { get; }
 
-        /// <summary>
-        /// Shear Area in the Y direction
-        /// </summary>
-        public double Asy { get; } = 0;
+        [Description("Z Distance from the centroid of the section to top edge of the section")]
+        public double Vz { get; }
 
-        /// <summary>
-        /// Shear Area in the Z direction
-        /// </summary>
-        public double Asz { get; } = 0;
+        [Description("Z Distance from the centroid of the section to bottom edge of the section")]
+        public double Vpz { get; }
+
+        [Description("Y Distance from the centroid of the section to right edge of the section")]
+        public double Vy { get; }
+
+        [Description("Y Distance from the centroid of the section to Left edge of the section")]
+        public double Vpy { get; }
+
+        [Description("Shear Area in the Y direction")]
+        public double Asy { get; }
+
+        [Description("Shear Area in the Z direction")]
+        public double Asz { get; }
 
 
         /***************************************************/

--- a/Structure_oM/SectionProperties/IGeometricalSection.cs
+++ b/Structure_oM/SectionProperties/IGeometricalSection.cs
@@ -1,18 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
 using BH.oM.Geometry.ShapeProfiles;
 
 namespace BH.oM.Structure.SectionProperties
 {
+    [Description("Interface for sections based on Shape profiles")]
     public interface IGeometricalSection : ISectionProperty
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Profile of the section, containing dimensions and section geometry")]
         IProfile SectionProfile { get; }
 
         /***************************************************/

--- a/Structure_oM/SectionProperties/IGeometricalSection.cs
+++ b/Structure_oM/SectionProperties/IGeometricalSection.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Geometry.ShapeProfiles;
+
+namespace BH.oM.Structure.SectionProperties
+{
+    public interface IGeometricalSection : ISectionProperty
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        IProfile SectionProfile { get; }
+
+        /***************************************************/
+    }
+}

--- a/Structure_oM/SectionProperties/ISectionProperty.cs
+++ b/Structure_oM/SectionProperties/ISectionProperty.cs
@@ -22,6 +22,7 @@
 
 using BH.oM.Base;
 using BH.oM.Structure.MaterialFragments;
+using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
@@ -31,96 +32,64 @@ namespace BH.oM.Structure.SectionProperties
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Material of the section")]
         IMaterialFragment Material { get; set; }
 
-        /// <summary>
-        /// Gross Area of the cross section
-        /// </summary>
+        [Description("Gross Area of the cross section")]
         double Area { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Y-Axis
-        /// </summary>
+        [Description("Radius of Gyration about the Y-Axis")]
         double Rgy { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Z-Axis
-        /// </summary>
+        [Description("Radius of Gyration about the Z-Axis")]
         double Rgz { get; }
 
-        /// <summary>
-        /// Torsion Constant
-        /// </summary>
+        [Description("Torsion Constant")]
         double J { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Y-Axis
-        /// </summary>
+        [Description("Moment of Inertia about the Y-Axis")]
         double Iy { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Z-Axis
-        /// </summary>
+        [Description("Moment of Inertia about the Z-Axis")]
         double Iz { get; }
 
-        /// <summary>
-        /// Warping Constant
-        /// </summary>
+        [Description("Warping Constant")]
         double Iw { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Y-Axis
-        /// </summary>
+        [Description("Elastic Modulus of the section about the Y-Axis")]
         double Wely { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Z-Axis
-        /// </summary>
+        [Description("Elastic Modulus of the section about the Z-Axis")]
         double Welz { get; }
-        /// <summary>
-        /// Plastic Modulus of the section about the Y-Axis
-        /// </summary>
+
+        [Description("Plastic Modulus of the section about the Y-Axis")]
         double Wply { get; }
 
-        /// <summary>
-        /// Plastic Modulus of the section about the Z-Axis
-        /// </summary>
+        [Description("Plastic Modulus of the section about the Z-Axis")]
         double Wplz { get; }
-        /// <summary>
-        /// Geometric centre of the section in the Z direction
-        /// </summary>
+
+        [Description("Geometric centre of the section in the Z direction")]
         double CentreZ { get; }
-        /// <summary>
-        /// Geometric centre of the section in the Y direction
-        /// </summary>
+
+        [Description("Geometric centre of the section in the Y direction")]
         double CentreY { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to top edge of the section
-        /// </summary>
+        [Description("Z Distance from the centroid of the section to top edge of the section")]
         double Vz { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to bottom edge of the section
-        /// </summary>
+        [Description("Z Distance from the centroid of the section to bottom edge of the section")]
         double Vpz { get; }
-        /// <summary>
-        /// Y Distance from the centroid of the section to right edge of the section
-        /// </summary>
+
+        [Description("Y Distance from the centroid of the section to right edge of the section")]
         double Vy { get; }
-        /// <summary>
-        /// Y Distance from the centroid of the section to Left edge of the section
-        /// </summary>
+
+        [Description("Y Distance from the centroid of the section to Left edge of the section")]
         double Vpy { get; }
 
-        /// <summary>
-        /// Shear Area in the Y direction
-        /// </summary>
+        [Description("Shear Area in the Y direction")]
         double Asy { get; }
 
-        /// <summary>
-        /// Shear Area in the Z direction
-        /// </summary>
+        [Description("Shear Area in the Z direction")]
         double Asz { get; }
 
         /***************************************************/

--- a/Structure_oM/SectionProperties/SteelSection.cs
+++ b/Structure_oM/SectionProperties/SteelSection.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry.ShapeProfiles;
+using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
@@ -37,110 +38,76 @@ namespace BH.oM.Structure.SectionProperties
 
         public SteelPlateRestraint PlateRestraint { get; set; } = SteelPlateRestraint.NoRestraint;
 
+        [Description("Material of the section")]
         public IMaterialFragment Material { get; set; } = null;
 
         /***************************************************/
         /**** Properties - Section profile              ****/
         /***************************************************/
 
+        [Description("Profile of the section, containing dimensions and section geometry")]
         public IProfile SectionProfile { get; }
-
 
         /***************************************************/
         /**** Properties - Section constants            ****/
         /***************************************************/
 
+        [Description("Gross Area of the cross section")]
+        public double Area { get; }
 
-        /// <summary>
-        /// Gross Area of the cross section
-        /// </summary>
-        public double Area { get; } = 0;
+        [Description("Radius of Gyration about the Y-Axis")]
+        public double Rgy { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Y-Axis
-        /// </summary>
-        public double Rgy { get; } = 0;
+        [Description("Radius of Gyration about the Z-Axis")]
+        public double Rgz { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Z-Axis
-        /// </summary>
-        public double Rgz { get; } = 0;
+        [Description("Torsion Constant")]
+        public double J { get; }
 
-        /// <summary>
-        /// Torsion Constant
-        /// </summary>
-        public double J { get; } = 0;
+        [Description("Moment of Inertia about the Y-Axis")]
+        public double Iy { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Y-Axis
-        /// </summary>
-        public double Iy { get; } = 0;
+        [Description("Moment of Inertia about the Z-Axis")]
+        public double Iz { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Z-Axis
-        /// </summary>
-        public double Iz { get; } = 0;
+        [Description("Warping Constant")]
+        public double Iw { get; }
 
-        /// <summary>
-        /// Warping Constant
-        /// </summary>
-        public double Iw { get; } = 0;
+        [Description("Elastic Modulus of the section about the Y-Axis")]
+        public double Wely { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wely { get; } = 0;
+        [Description("Elastic Modulus of the section about the Z-Axis")]
+        public double Welz { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Welz { get; } = 0;
-        /// <summary>
-        /// Plastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wply { get; } = 0;
+        [Description("Plastic Modulus of the section about the Y-Axis")]
+        public double Wply { get; }
 
-        /// <summary>
-        /// Plastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Wplz { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Z direction
-        /// </summary>
-        public double CentreZ { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Y direction
-        /// </summary>
-        public double CentreY { get; } = 0;
+        [Description("Plastic Modulus of the section about the Z-Axis")]
+        public double Wplz { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to top edge of the section
-        /// </summary>
-        public double Vz { get; } = 0;
+        [Description("Geometric centre of the section in the Z direction")]
+        public double CentreZ { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to bottom edge of the section
-        /// </summary>
-        public double Vpz { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to right edge of the section
-        /// </summary>
-        public double Vy { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to Left edge of the section
-        /// </summary>
-        public double Vpy { get; } = 0;
+        [Description("Geometric centre of the section in the Y direction")]
+        public double CentreY { get; }
 
-        /// <summary>
-        /// Shear Area in the Y direction
-        /// </summary>
-        public double Asy { get; } = 0;
+        [Description("Z Distance from the centroid of the section to top edge of the section")]
+        public double Vz { get; }
 
-        /// <summary>
-        /// Shear Area in the Z direction
-        /// </summary>
-        public double Asz { get; } = 0;
+        [Description("Z Distance from the centroid of the section to bottom edge of the section")]
+        public double Vpz { get; }
 
+        [Description("Y Distance from the centroid of the section to right edge of the section")]
+        public double Vy { get; }
+
+        [Description("Y Distance from the centroid of the section to Left edge of the section")]
+        public double Vpy { get; }
+
+        [Description("Shear Area in the Y direction")]
+        public double Asy { get; }
+
+        [Description("Shear Area in the Z direction")]
+        public double Asz { get; }
 
         /***************************************************/
         /**** Constructors                              ****/

--- a/Structure_oM/SectionProperties/SteelSection.cs
+++ b/Structure_oM/SectionProperties/SteelSection.cs
@@ -27,7 +27,7 @@ using BH.oM.Geometry.ShapeProfiles;
 namespace BH.oM.Structure.SectionProperties
 {
 
-    public class SteelSection : BHoMObject, ISectionProperty, IImmutable
+    public class SteelSection : BHoMObject, IGeometricalSection, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Structure_oM/SectionProperties/TimberSection.cs
+++ b/Structure_oM/SectionProperties/TimberSection.cs
@@ -23,6 +23,8 @@
 using BH.oM.Base;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry.ShapeProfiles;
+ 
+using System.ComponentModel;
 
 namespace BH.oM.Structure.SectionProperties
 {
@@ -33,109 +35,76 @@ namespace BH.oM.Structure.SectionProperties
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Material of the section")]
         public IMaterialFragment Material { get; set; } = null;
 
         /***************************************************/
         /**** Properties - Section profile              ****/
         /***************************************************/
 
+        [Description("Profile of the section, containing dimensions and section geometry")]
         public IProfile SectionProfile { get; }
-
 
         /***************************************************/
         /**** Properties - Section constants            ****/
         /***************************************************/
 
+        [Description("Gross Area of the cross section")]
+        public double Area { get; }
 
-        /// <summary>
-        /// Gross Area of the cross section
-        /// </summary>
-        public double Area { get; } = 0;
+        [Description("Radius of Gyration about the Y-Axis")]
+        public double Rgy { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Y-Axis
-        /// </summary>
-        public double Rgy { get; } = 0;
+        [Description("Radius of Gyration about the Z-Axis")]
+        public double Rgz { get; }
 
-        /// <summary>
-        /// Radius of Gyration about the Z-Axis
-        /// </summary>
-        public double Rgz { get; } = 0;
+        [Description("Torsion Constant")]
+        public double J { get; }
 
-        /// <summary>
-        /// Torsion Constant
-        /// </summary>
-        public double J { get; } = 0;
+        [Description("Moment of Inertia about the Y-Axis")]
+        public double Iy { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Y-Axis
-        /// </summary>
-        public double Iy { get; } = 0;
+        [Description("Moment of Inertia about the Z-Axis")]
+        public double Iz { get; }
 
-        /// <summary>
-        /// Moment of Inertia about the Z-Axis
-        /// </summary>
-        public double Iz { get; } = 0;
+        [Description("Warping Constant")]
+        public double Iw { get; }
 
-        /// <summary>
-        /// Warping Constant
-        /// </summary>
-        public double Iw { get; } = 0;
+        [Description("Elastic Modulus of the section about the Y-Axis")]
+        public double Wely { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wely { get; } = 0;
+        [Description("Elastic Modulus of the section about the Z-Axis")]
+        public double Welz { get; }
 
-        /// <summary>
-        /// Elastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Welz { get; } = 0;
-        /// <summary>
-        /// Plastic Modulus of the section about the Y-Axis
-        /// </summary>
-        public double Wply { get; } = 0;
+        [Description("Plastic Modulus of the section about the Y-Axis")]
+        public double Wply { get; }
 
-        /// <summary>
-        /// Plastic Modulus of the section about the Z-Axis
-        /// </summary>
-        public double Wplz { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Z direction
-        /// </summary>
-        public double CentreZ { get; } = 0;
-        /// <summary>
-        /// Geometric centre of the section in the Y direction
-        /// </summary>
-        public double CentreY { get; } = 0;
+        [Description("Plastic Modulus of the section about the Z-Axis")]
+        public double Wplz { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to top edge of the section
-        /// </summary>
-        public double Vz { get; } = 0;
+        [Description("Geometric centre of the section in the Z direction")]
+        public double CentreZ { get; }
 
-        /// <summary>
-        /// Z Distance from the centroid of the section to bottom edge of the section
-        /// </summary>
-        public double Vpz { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to right edge of the section
-        /// </summary>
-        public double Vy { get; } = 0;
-        /// <summary>
-        /// Y Distance from the centroid of the section to Left edge of the section
-        /// </summary>
-        public double Vpy { get; } = 0;
+        [Description("Geometric centre of the section in the Y direction")]
+        public double CentreY { get; }
 
-        /// <summary>
-        /// Shear Area in the Y direction
-        /// </summary>
-        public double Asy { get; } = 0;
+        [Description("Z Distance from the centroid of the section to top edge of the section")]
+        public double Vz { get; }
 
-        /// <summary>
-        /// Shear Area in the Z direction
-        /// </summary>
-        public double Asz { get; } = 0;
+        [Description("Z Distance from the centroid of the section to bottom edge of the section")]
+        public double Vpz { get; }
+
+        [Description("Y Distance from the centroid of the section to right edge of the section")]
+        public double Vy { get; }
+
+        [Description("Y Distance from the centroid of the section to Left edge of the section")]
+        public double Vpy { get; }
+
+        [Description("Shear Area in the Y direction")]
+        public double Asy { get; }
+
+        [Description("Shear Area in the Z direction")]
+        public double Asz { get; }
 
 
         /***************************************************/

--- a/Structure_oM/SectionProperties/TimberSection.cs
+++ b/Structure_oM/SectionProperties/TimberSection.cs
@@ -1,0 +1,198 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Structure.MaterialFragments;
+using BH.oM.Geometry.ShapeProfiles;
+
+namespace BH.oM.Structure.SectionProperties
+{
+
+    public class TimberSection : BHoMObject, ISectionProperty, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public IMaterialFragment Material { get; set; } = null;
+
+        /***************************************************/
+        /**** Properties - Section profile              ****/
+        /***************************************************/
+
+        public IProfile SectionProfile { get; }
+
+
+        /***************************************************/
+        /**** Properties - Section constants            ****/
+        /***************************************************/
+
+
+        /// <summary>
+        /// Gross Area of the cross section
+        /// </summary>
+        public double Area { get; } = 0;
+
+        /// <summary>
+        /// Radius of Gyration about the Y-Axis
+        /// </summary>
+        public double Rgy { get; } = 0;
+
+        /// <summary>
+        /// Radius of Gyration about the Z-Axis
+        /// </summary>
+        public double Rgz { get; } = 0;
+
+        /// <summary>
+        /// Torsion Constant
+        /// </summary>
+        public double J { get; } = 0;
+
+        /// <summary>
+        /// Moment of Inertia about the Y-Axis
+        /// </summary>
+        public double Iy { get; } = 0;
+
+        /// <summary>
+        /// Moment of Inertia about the Z-Axis
+        /// </summary>
+        public double Iz { get; } = 0;
+
+        /// <summary>
+        /// Warping Constant
+        /// </summary>
+        public double Iw { get; } = 0;
+
+        /// <summary>
+        /// Elastic Modulus of the section about the Y-Axis
+        /// </summary>
+        public double Wely { get; } = 0;
+
+        /// <summary>
+        /// Elastic Modulus of the section about the Z-Axis
+        /// </summary>
+        public double Welz { get; } = 0;
+        /// <summary>
+        /// Plastic Modulus of the section about the Y-Axis
+        /// </summary>
+        public double Wply { get; } = 0;
+
+        /// <summary>
+        /// Plastic Modulus of the section about the Z-Axis
+        /// </summary>
+        public double Wplz { get; } = 0;
+        /// <summary>
+        /// Geometric centre of the section in the Z direction
+        /// </summary>
+        public double CentreZ { get; } = 0;
+        /// <summary>
+        /// Geometric centre of the section in the Y direction
+        /// </summary>
+        public double CentreY { get; } = 0;
+
+        /// <summary>
+        /// Z Distance from the centroid of the section to top edge of the section
+        /// </summary>
+        public double Vz { get; } = 0;
+
+        /// <summary>
+        /// Z Distance from the centroid of the section to bottom edge of the section
+        /// </summary>
+        public double Vpz { get; } = 0;
+        /// <summary>
+        /// Y Distance from the centroid of the section to right edge of the section
+        /// </summary>
+        public double Vy { get; } = 0;
+        /// <summary>
+        /// Y Distance from the centroid of the section to Left edge of the section
+        /// </summary>
+        public double Vpy { get; } = 0;
+
+        /// <summary>
+        /// Shear Area in the Y direction
+        /// </summary>
+        public double Asy { get; } = 0;
+
+        /// <summary>
+        /// Shear Area in the Z direction
+        /// </summary>
+        public double Asz { get; } = 0;
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        //Main constructor setting all of the properties of the object
+        public TimberSection(
+            IProfile sectionProfile,
+
+            double area,
+            double rgy,
+            double rgz,
+            double j,
+            double iy,
+            double iz,
+            double iw,
+            double wely,
+            double welz,
+            double wply,
+            double wplz,
+            double centreZ,
+            double centreY,
+            double vz,
+            double vpz,
+            double vy,
+            double vpy,
+            double asy,
+            double asz)
+
+        {
+
+            SectionProfile = sectionProfile;
+
+            Area = area;
+            Rgy = rgy;
+            Rgz = rgz;
+            J = j;
+            Iy = iy;
+            Iz = iz;
+            Iw = iw;
+            Wely = wely;
+            Welz = welz;
+            Wply = wply;
+            Wplz = wplz;
+            CentreZ = centreZ;
+            CentreY = centreY;
+            Vz = vz;
+            Vpz = vpz;
+            Vy = vy;
+            Vpy = vpy;
+            Asy = asy;
+            Asz = asz;
+
+        }
+
+
+    }
+}
+

--- a/Structure_oM/Structure_oM.csproj
+++ b/Structure_oM/Structure_oM.csproj
@@ -91,6 +91,8 @@
     <Compile Include="MaterialFragments\Aluminium.cs" />
     <Compile Include="MaterialFragments\Concrete.cs" />
     <Compile Include="MaterialFragments\Enums\MaterialType.cs" />
+    <Compile Include="MaterialFragments\GenericIsotropicMaterial.cs" />
+    <Compile Include="MaterialFragments\GenericOrthotropicMaterial.cs" />
     <Compile Include="MaterialFragments\IIsotropic.cs" />
     <Compile Include="MaterialFragments\IOrthotropic.cs" />
     <Compile Include="MaterialFragments\IMaterialFragment.cs" />
@@ -106,8 +108,11 @@
     <Compile Include="Requests\MeshResultRequest.cs" />
     <Compile Include="Requests\NodeResultRequest.cs" />
     <Compile Include="Results\Bar Results\BarDisplacement.cs" />
+    <Compile Include="SectionProperties\AluminiumSection.cs" />
     <Compile Include="SectionProperties\Enums\CableType.cs" />
     <Compile Include="Constraints\Enums\DOFType.cs" />
+    <Compile Include="SectionProperties\GenericSection.cs" />
+    <Compile Include="SectionProperties\IGeometricalSection.cs" />
     <Compile Include="SectionProperties\TimberSection.cs" />
     <Compile Include="SurfaceProperties\Enums\LoadPanelSupportConditions.cs" />
     <Compile Include="SurfaceProperties\Enums\PanelDirection.cs" />

--- a/Structure_oM/Structure_oM.csproj
+++ b/Structure_oM/Structure_oM.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Results\Bar Results\BarDisplacement.cs" />
     <Compile Include="SectionProperties\Enums\CableType.cs" />
     <Compile Include="Constraints\Enums\DOFType.cs" />
+    <Compile Include="SectionProperties\TimberSection.cs" />
     <Compile Include="SurfaceProperties\Enums\LoadPanelSupportConditions.cs" />
     <Compile Include="SurfaceProperties\Enums\PanelDirection.cs" />
     <Compile Include="SurfaceProperties\Enums\PanelModifier.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #555 
Closes #564 
Closes #588 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/Structure_oM/Issue555-AddingTimberALuminiumAbdGenericSections?csf=1&e=HMfIUS

Note, testfile requires https://github.com/BHoM/BHoM_Engine/pull/1410

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Adding TimberSection
- Adding AluminiumSection
- Adding GenericSection to be used for section types not yet explicitly supported
- Adding GenericIsotropicMaterial
- Adding GenericOrthotropicMaterial
- Adding new IGeometricalSection interface for all sections based on IProfiles
- `IMaterialFragment` now implements `IBHoMFragment`

### Additional comments
<!-- As required -->
As this is touching the materials, thought this would be a good time to resolve #588 as well, simply making the structural material fragments into `IBHoMFragments`. Still outstanding on the physical side to remove the `IMaterialProperties` and for the physical material to make use of the fragment list instead. @FraserGreenroyd 