### PR TITLE
NotExposedAttribute

### DIFF
--- a/Reflection_oM/Attributes/NotExposedAttribute.cs
+++ b/Reflection_oM/Attributes/NotExposedAttribute.cs
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Reflection.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class NotExposedAttribute : Attribute, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Description { get; private set; } = "";
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public NotExposedAttribute(string description = "")
+        {
+            Description = description;
+        }
+
+
+        /***************************************************/
+    }
+}

--- a/Reflection_oM/Reflection_oM.csproj
+++ b/Reflection_oM/Reflection_oM.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Attributes\DeprecatedAttribute.cs" />
     <Compile Include="Attributes\InputAttribute.cs" />
     <Compile Include="Attributes\MultiOutputAttribute.cs" />
+    <Compile Include="Attributes\NotExposedAttribute.cs" />
     <Compile Include="Attributes\NotImplementedAttribute.cs" />
     <Compile Include="Attributes\OutputAttribute.cs" />
     <Compile Include="Attributes\ReleasedAttribute.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #661 
A attribute which hides a method from the UI

### Test files
<!-- Link to test files to validate the proposed changes -->
Test any file to make sure it doesn't break anything.
But as this PR is not for setting anything as `NotExposed` no proper test file will be provided for that, instead set a current method as `NotExposed` and test that it disappeared from the UI

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->