### PR TITLE
Data_oM: Add attribute dictionary to GraphNode and GraphLink

### DIFF
--- a/Data_oM/Collections/GraphLink.cs
+++ b/Data_oM/Collections/GraphLink.cs
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
+using System.Collections.Generic;
 
 namespace BH.oM.Data.Collections
 {
@@ -28,7 +29,7 @@ namespace BH.oM.Data.Collections
         /**** Properties                                ****/
         /***************************************************/
 
-        public double Weight { get; set; } = 1.0;
+        public Dictionary<string,object> Attributes { get; set; } = new Dictionary<string, object>();
 
         public GraphNode<T> StartNode { get; set; } = new GraphNode<T>();
 

--- a/Data_oM/Collections/GraphLink.cs
+++ b/Data_oM/Collections/GraphLink.cs
@@ -30,11 +30,9 @@ namespace BH.oM.Data.Collections
         /***************************************************/
 
         public Dictionary<string,object> Attributes { get; set; } = new Dictionary<string, object>();
-
+        public double Weight { get; set; } = 1.0;
         public GraphNode<T> StartNode { get; set; } = new GraphNode<T>();
-
         public GraphNode<T> EndNode { get; set; } = new GraphNode<T>();
-
 
         /***************************************************/
     }

--- a/Data_oM/Collections/GraphNode.cs
+++ b/Data_oM/Collections/GraphNode.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System.Collections.Generic;
+
 namespace BH.oM.Data.Collections
 {
     public class GraphNode<T> : IDataStructure
@@ -30,6 +32,7 @@ namespace BH.oM.Data.Collections
 
         public T Value { get; set; } = default(T);
 
+        public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();
 
         /***************************************************/
         /**** Explicit Casting                          ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
Adding a generic dictionary for both node and edge attributes. Much like those used in NetworkX https://networkx.github.io/documentation/stable/reference/glossary.html#term-node-attribute
https://networkx.github.io/documentation/stable/reference/glossary.html#term-edge-attribute 

Closes #633 
Just edging this forward and hoping to get back to the discussion. 

### Additional comments
Also relates to:
https://github.com/BuroHappoldEngineering/Qualia_Toolkit/pull/5
https://github.com/BuroHappoldEngineering/Qualia_Toolkit/issues/3
Plus:
Already I'm using decision graphs for the venue performance rating work. This proposed change or similar will help massively. 
A weighting decision graph works using the existing BHoM Graph but its also nice to store scores as a graph. This allows querying the graph for the score at any sub node without needing to compute the score. 
I would also like to bring to the discussion the need for graph methods. I have implemented a method for depth first graph traversal and building an adjacency list both out of necessity for the Scoring using a decision graph. These are generic methods so should be in another namespace ultimately.
I know these additional comments are :rewind: sprawling ⏩  :octopus: but think I need to get it all down somewhere and get some critical 👀 eyes on it 😃 .