### PR TITLE
Programming_oM: Adding Initial code 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,5 +20,6 @@
 /MEP_oM @kayleighhoude @FraserGreenroyd
 /Physical_oM @al-fisher @rwemay @IsakNaslundBh @FraserGreenroyd
 /Planning_oM @rwemay @al-fisher
+/Programming_oM @adecler @FraserGreenroyd @al-fisher
 /Reflection_oM @adecler @FraserGreenroyd @al-fisher
 /Structure_oM @IsakNaslundBh @rwemay

--- a/BHoM.sln
+++ b/BHoM.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.757
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BHoM", "BHoM\BHoM.csproj", "{94D88927-62A2-48FC-8EFE-D139B67A3373}"
 EndProject
@@ -41,6 +41,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MEP_oM", "MEP_oM\MEP_oM.csproj", "{088711C9-AC7E-409D-A1CD-A65FBABD88DA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quantities_oM", "Quantities_oM\Quantities_oM.csproj", "{2A5D5A00-D404-4F7E-B771-2FC837145361}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Programming_oM", "Programming_oM\Programming_oM.csproj", "{B1B5AA71-143B-4EDB-9D9B-08CC8DBABF4D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -120,6 +122,10 @@ Global
 		{2A5D5A00-D404-4F7E-B771-2FC837145361}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A5D5A00-D404-4F7E-B771-2FC837145361}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A5D5A00-D404-4F7E-B771-2FC837145361}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1B5AA71-143B-4EDB-9D9B-08CC8DBABF4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1B5AA71-143B-4EDB-9D9B-08CC8DBABF4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1B5AA71-143B-4EDB-9D9B-08CC8DBABF4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1B5AA71-143B-4EDB-9D9B-08CC8DBABF4D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Programming_oM/Nodes/BlockNode.cs
+++ b/Programming_oM/Nodes/BlockNode.cs
@@ -1,6 +1,30 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +32,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("Represents a group of syntax nodes covered by a common description. This is equivalent to a block of code inside a method.")]
     public class BlockNode : BHoMObject, INode, IImmutable
     {
         /***************************************************/
@@ -31,6 +56,9 @@ namespace BH.oM.Programming
         /**** Constructors                              ****/
         /***************************************************/
 
+        [Description("Returns a BlockNode to be used in a BHoM Syntax Tree.")]
+        [Input("content", "List of syntax nodes to include in the group.")]
+        [Input("description", "Description covering the set of nodes including in this block.")]
         public BlockNode(List<INode> content, string description = "")
         {
             List<ReceiverParam> receivers = content.SelectMany(n => n.Inputs.Where(x => x.SourceId != Guid.Empty)).ToList();

--- a/Programming_oM/Nodes/BlockNode.cs
+++ b/Programming_oM/Nodes/BlockNode.cs
@@ -1,0 +1,64 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class BlockNode : BHoMObject, INode, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public List<INode> InternalNodes { get; } = new List<INode>();
+
+        public string Description { get; set; } = "";
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = false;
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public BlockNode(List<INode> content, string description = "")
+        {
+            List<ReceiverParam> receivers = content.SelectMany(n => n.Inputs.Where(x => x.SourceId != Guid.Empty)).ToList();
+            List<DataParam> emiters = content.SelectMany(n => n.Outputs.Where(x => x.TargetIds.Count > 0)).ToList();
+
+            List<Guid> receiverIds = receivers.Select(x => x.BHoM_Guid).ToList();
+            List<Guid> emiterIds = emiters.Select(x => x.BHoM_Guid).ToList();
+
+            Outputs = emiters.Where(x => x.TargetIds.Intersect(receiverIds).Count() == 0)
+                                        .Select(x =>
+                                        {
+                                            DataParam copy = x.GetShallowClone() as DataParam;
+                                            copy.ParentId = this.BHoM_Guid;
+                                            return copy;
+                                        }).ToList();
+
+            Inputs = receivers.Where(x => !emiterIds.Contains(x.SourceId))
+                                        .Select(x =>
+                                        {
+                                            ReceiverParam copy = x.GetShallowClone() as ReceiverParam;
+                                            copy.ParentId = this.BHoM_Guid;
+                                            return copy;
+                                        }).ToList();
+
+            InternalNodes = content;
+            Description = description;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/ClusterNode.cs
+++ b/Programming_oM/Nodes/ClusterNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("Represents a cluster of syntax nodes. This is equivalent to a method declaration.")]
     public class ClusterNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/ClusterNode.cs
+++ b/Programming_oM/Nodes/ClusterNode.cs
@@ -1,0 +1,31 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class ClusterNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public ClusterContent Content { get; set; } = null;
+
+        public string Description { get; set; } = "";
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = false;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/ConstructorNode.cs
+++ b/Programming_oM/Nodes/ConstructorNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node representing a call to a constructor.")]
     public class ConstructorNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/ConstructorNode.cs
+++ b/Programming_oM/Nodes/ConstructorNode.cs
@@ -1,0 +1,31 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class ConstructorNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public ConstructorInfo Constructor { get; set; } = null;
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = true;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/CustomObjectNode.cs
+++ b/Programming_oM/Nodes/CustomObjectNode.cs
@@ -1,0 +1,29 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class CustomObjectNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = true;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/CustomObjectNode.cs
+++ b/Programming_oM/Nodes/CustomObjectNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node representing the creation of a BHoM Custom object.")]
     public class CustomObjectNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/ExplodeNode.cs
+++ b/Programming_oM/Nodes/ExplodeNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node corresponding to a call to the BHoM Explode method/component.")]
     public class ExplodeNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/ExplodeNode.cs
+++ b/Programming_oM/Nodes/ExplodeNode.cs
@@ -1,0 +1,29 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class ExplodeNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = true;
+
+        public bool IsDeclaration { get; set; } = false;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/GetPropertyNode.cs
+++ b/Programming_oM/Nodes/GetPropertyNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node corresponding to a call to the BHoM GetProperty method/component.")]
     public class GetPropertyNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/GetPropertyNode.cs
+++ b/Programming_oM/Nodes/GetPropertyNode.cs
@@ -1,0 +1,29 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class GetPropertyNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = true;
+
+        public bool IsDeclaration { get; set; } = false;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/INode.cs
+++ b/Programming_oM/Nodes/INode.cs
@@ -1,11 +1,35 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("Interface common to all syntax nodes")]
     public interface INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/INode.cs
+++ b/Programming_oM/Nodes/INode.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public interface INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        List<ReceiverParam> Inputs { get; set; }
+
+        List<DataParam> Outputs { get; set; }
+
+        string Description { get; set; }
+
+        string Name { get; set; }
+
+        Guid BHoM_Guid { get; set; }
+
+        bool IsInline { get; set; }
+
+        bool IsDeclaration { get; set; }
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/InitialiserNode.cs
+++ b/Programming_oM/Nodes/InitialiserNode.cs
@@ -1,0 +1,31 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class InitialiserNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public Type ObjectType { get; set; } = null;
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = true;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/InitialiserNode.cs
+++ b/Programming_oM/Nodes/InitialiserNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node representing the initialisation of an object. \nIn C#, this would be equivalent to something like 'new Point {X = x, Y = y }'")]
     public class InitialiserNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/LibraryNode.cs
+++ b/Programming_oM/Nodes/LibraryNode.cs
@@ -1,0 +1,31 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class LibraryNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string SourceFile { get; set; } = "";
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = true;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/LibraryNode.cs
+++ b/Programming_oM/Nodes/LibraryNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node corresponding to a call to the CreateData BHoM component.")]
     public class LibraryNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/LoopNode.cs
+++ b/Programming_oM/Nodes/LoopNode.cs
@@ -1,0 +1,64 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class LoopNode : BHoMObject, INode, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public List<INode> InternalNodes { get; } = new List<INode>();
+
+        public string Description { get; set; } = "";
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = false;
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public LoopNode(List<INode> content, string description = "")
+        {
+            List<ReceiverParam> receivers = content.SelectMany(n => n.Inputs.Where(x => x.SourceId != Guid.Empty)).ToList();
+            List<DataParam> emiters = content.SelectMany(n => n.Outputs.Where(x => x.TargetIds.Count > 0)).ToList();
+
+            List<Guid> receiverIds = receivers.Select(x => x.BHoM_Guid).ToList();
+            List<Guid> emiterIds = emiters.Select(x => x.BHoM_Guid).ToList();
+
+            Outputs = emiters.Where(x => x.TargetIds.Intersect(receiverIds).Count() == 0)
+                                        .Select(x =>
+                                        {
+                                            DataParam copy = x.GetShallowClone() as DataParam;
+                                            copy.ParentId = this.BHoM_Guid;
+                                            return copy;
+                                        }).ToList();
+
+            Inputs = receivers.Where(x => !emiterIds.Contains(x.SourceId))
+                                        .Select(x =>
+                                        {
+                                            ReceiverParam copy = x.GetShallowClone() as ReceiverParam;
+                                            copy.ParentId = this.BHoM_Guid;
+                                            return copy;
+                                        }).ToList();
+
+            InternalNodes = content;
+            Description = description;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/LoopNode.cs
+++ b/Programming_oM/Nodes/LoopNode.cs
@@ -1,6 +1,30 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +32,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node corresponding to a code loop.")]
     public class LoopNode : BHoMObject, INode, IImmutable
     {
         /***************************************************/
@@ -31,6 +56,9 @@ namespace BH.oM.Programming
         /**** Constructors                              ****/
         /***************************************************/
 
+        [Description("Returns a LoopNode to be used in a BHoM Syntax Tree.")]
+        [Input("content", "List of syntax nodes to include in the loop.")]
+        [Input("description", "Description of what this loop is doing.")]
         public LoopNode(List<INode> content, string description = "")
         {
             List<ReceiverParam> receivers = content.SelectMany(n => n.Inputs.Where(x => x.SourceId != Guid.Empty)).ToList();

--- a/Programming_oM/Nodes/MethodNode.cs
+++ b/Programming_oM/Nodes/MethodNode.cs
@@ -1,0 +1,31 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class MethodNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public MethodInfo Method { get; set; } = null;
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = true;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/MethodNode.cs
+++ b/Programming_oM/Nodes/MethodNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node representing a call to a method.")]
     public class MethodNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/ParamNode.cs
+++ b/Programming_oM/Nodes/ParamNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node that is in itself a single data parameter.")]
     public class ParamNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/ParamNode.cs
+++ b/Programming_oM/Nodes/ParamNode.cs
@@ -1,0 +1,29 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class ParamNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = true;
+
+        public bool IsDeclaration { get; set; } = false;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/SetPropertyNode.cs
+++ b/Programming_oM/Nodes/SetPropertyNode.cs
@@ -1,0 +1,29 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class SetPropertyNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = false;
+
+        public bool IsDeclaration { get; set; } = false;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Nodes/SetPropertyNode.cs
+++ b/Programming_oM/Nodes/SetPropertyNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node corresponding to a call to the BHoM SetProperty method/component.")]
     public class SetPropertyNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/TypeNode.cs
+++ b/Programming_oM/Nodes/TypeNode.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A syntax node representing the creation of an object Type.")]
     public class TypeNode : BHoMObject, INode
     {
         /***************************************************/

--- a/Programming_oM/Nodes/TypeNode.cs
+++ b/Programming_oM/Nodes/TypeNode.cs
@@ -1,0 +1,31 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class TypeNode : BHoMObject, INode
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public Type Type { get; set; } = null;
+
+        public string Description { get; set; } = "";
+
+        public List<ReceiverParam> Inputs { get; set; } = new List<ReceiverParam>();
+
+        public List<DataParam> Outputs { get; set; } = new List<DataParam>();
+
+        public bool IsInline { get; set; } = true;
+
+        public bool IsDeclaration { get; set; } = false;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Others/ClusterContent.cs
+++ b/Programming_oM/Others/ClusterContent.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("Content of a Cluster syntax node.")]
     public class ClusterContent : BHoMObject
     {
         /***************************************************/

--- a/Programming_oM/Others/ClusterContent.cs
+++ b/Programming_oM/Others/ClusterContent.cs
@@ -1,0 +1,27 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class ClusterContent : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public List<INode> InternalNodes { get; set; } = new List<INode>();
+
+        public List<NodeGroup> NodeGroups { get; set; } = new List<NodeGroup>();
+
+        public List<DataParam> Inputs { get; set; } = new List<DataParam>();
+
+        public List<ReceiverParam> Outputs { get; set; } = new List<ReceiverParam>();
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Others/NodeGroup.cs
+++ b/Programming_oM/Others/NodeGroup.cs
@@ -1,6 +1,29 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,6 +31,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("A group of syntax nodes referenced by their Guid.")]
     public class NodeGroup : BHoMObject
     {
         /***************************************************/

--- a/Programming_oM/Others/NodeGroup.cs
+++ b/Programming_oM/Others/NodeGroup.cs
@@ -1,0 +1,26 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class NodeGroup : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Description { get; set; } = "";
+
+        public List<Guid> NodeIds { get; set; } = new List<Guid>();
+
+        public List<NodeGroup> InternalGroups { get; set; } = new List<NodeGroup>();
+
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Params/DataParam.cs
+++ b/Programming_oM/Params/DataParam.cs
@@ -1,0 +1,28 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class DataParam : BHoMObject, INodeParam
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public object Data { get; set; } = null;
+
+        public List<Guid> TargetIds { get; set; } = new List<Guid>();
+
+        public Guid ParentId { get; set; } = Guid.Empty;
+
+        public Type DataType { get; set; } = typeof(object);
+
+        public string Description { get; set; } = "";
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Params/DataParam.cs
+++ b/Programming_oM/Params/DataParam.cs
@@ -1,12 +1,36 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("Output of a syntax node.")]
     public class DataParam : BHoMObject, INodeParam
     {
         /***************************************************/
@@ -15,10 +39,13 @@ namespace BH.oM.Programming
 
         public object Data { get; set; } = null;
 
+        [Description("Guids of the connected Receiver parameters.")]
         public List<Guid> TargetIds { get; set; } = new List<Guid>();
 
+        [Description("Guids of the parent syntax node.")]
         public Guid ParentId { get; set; } = Guid.Empty;
 
+        [Description("Type of data expected by this parameter.")]
         public Type DataType { get; set; } = typeof(object);
 
         public string Description { get; set; } = "";

--- a/Programming_oM/Params/INodeParam.cs
+++ b/Programming_oM/Params/INodeParam.cs
@@ -1,11 +1,35 @@
-﻿using System;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("Interface common to all syntax nodes parameters")]
     public interface INodeParam
     {
         /***************************************************/

--- a/Programming_oM/Params/INodeParam.cs
+++ b/Programming_oM/Params/INodeParam.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public interface INodeParam
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        Guid ParentId { get; set; }
+
+        Type DataType { get; set; }
+
+        string Description { get; set; }
+
+        string Name { get; set; }
+
+        Guid BHoM_Guid { get; set; }
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Params/ReceiverParam.cs
+++ b/Programming_oM/Params/ReceiverParam.cs
@@ -1,22 +1,49 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace BH.oM.Programming
 {
+    [Description("Input of a syntax node.")]
     public class ReceiverParam : BHoMObject, INodeParam
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Guids of the connected data parameters feeding into this.")]
         public Guid SourceId { get; set; } = Guid.Empty;
 
+        [Description("Guids of the parent syntax node.")]
         public Guid ParentId { get; set; } = Guid.Empty;
 
+        [Description("Type of data expected by this parameter.")]
         public Type DataType { get; set; } = typeof(object);
 
         public string Description { get; set; } = "";

--- a/Programming_oM/Params/ReceiverParam.cs
+++ b/Programming_oM/Params/ReceiverParam.cs
@@ -1,0 +1,28 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Programming
+{
+    public class ReceiverParam : BHoMObject, INodeParam
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public Guid SourceId { get; set; } = Guid.Empty;
+
+        public Guid ParentId { get; set; } = Guid.Empty;
+
+        public Type DataType { get; set; } = typeof(object);
+
+        public string Description { get; set; } = "";
+
+        public object DefaultValue { get; set; } = null;
+
+        /***************************************************/
+    }
+}

--- a/Programming_oM/Programming_oM.csproj
+++ b/Programming_oM/Programming_oM.csproj
@@ -68,6 +68,11 @@
       <Name>BHoM</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\Reflection_oM\Reflection_oM.csproj">
+      <Project>{29E6DCD7-270A-45CC-AC0B-6C024287645E}</Project>
+      <Name>Reflection_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Programming_oM/Programming_oM.csproj
+++ b/Programming_oM/Programming_oM.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B1B5AA71-143B-4EDB-9D9B-08CC8DBABF4D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.oM.Programming</RootNamespace>
+    <AssemblyName>Programming_oM</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Nodes\BlockNode.cs" />
+    <Compile Include="Nodes\ClusterNode.cs" />
+    <Compile Include="Nodes\ConstructorNode.cs" />
+    <Compile Include="Nodes\CustomObjectNode.cs" />
+    <Compile Include="Nodes\ExplodeNode.cs" />
+    <Compile Include="Nodes\GetPropertyNode.cs" />
+    <Compile Include="Nodes\InitialiserNode.cs" />
+    <Compile Include="Nodes\INode.cs" />
+    <Compile Include="Nodes\LibraryNode.cs" />
+    <Compile Include="Nodes\LoopNode.cs" />
+    <Compile Include="Nodes\MethodNode.cs" />
+    <Compile Include="Nodes\ParamNode.cs" />
+    <Compile Include="Nodes\SetPropertyNode.cs" />
+    <Compile Include="Nodes\TypeNode.cs" />
+    <Compile Include="Others\ClusterContent.cs" />
+    <Compile Include="Others\NodeGroup.cs" />
+    <Compile Include="Params\DataParam.cs" />
+    <Compile Include="Params\INodeParam.cs" />
+    <Compile Include="Params\ReceiverParam.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BHoM\BHoM.csproj">
+      <Project>{94d88927-62a2-48fc-8efe-d139b67a3373}</Project>
+      <Name>BHoM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Programming_oM/Properties/AssemblyInfo.cs
+++ b/Programming_oM/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Programming_oM")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Programming_oM")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b1b5aa71-143b-4edb-9d9b-08cc8dbabf4d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.1.0.0")]


### PR DESCRIPTION
### NOTE: Depends on 


   
### Issues addressed by this PR

Provides the oM for the task covered by this PR: https://github.com/BHoM/Grasshopper_Toolkit/pull/447

This effectively removes the dependency of Grasshopper with the Node2Code toolkit. It is critical to do so since some of the code in GH related to Node2Code will later be migrated to BHoM_UI.

In term of review, this is mainly a question of testing that the Grasshopper PR still works the same ways now that the Om has been migrated.

### Additional comments
This is simply a migration of the code from https://github.com/BHoM/Node2Code_Toolkit/pull/2 with no change other than the namespace
