### PR TITLE
Reflection_oM: Adding quantity attributes to inputs and outputs

### DIFF
--- a/Quantities_oM/Attributes/Acceleration.cs
+++ b/Quantities_oM/Attributes/Acceleration.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Acceleration : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/AmountOfSubstance.cs
+++ b/Quantities_oM/Attributes/AmountOfSubstance.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class AmountOfSubstance : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Angle.cs
+++ b/Quantities_oM/Attributes/Angle.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Angle : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/AngularAcceleration.cs
+++ b/Quantities_oM/Attributes/AngularAcceleration.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class AngularAcceleration : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/AngularVelocity.cs
+++ b/Quantities_oM/Attributes/AngularVelocity.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class AngularVelocity : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Area.cs
+++ b/Quantities_oM/Attributes/Area.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Area : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Density.cs
+++ b/Quantities_oM/Attributes/Density.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Density : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/ElectricCurrent.cs
+++ b/Quantities_oM/Attributes/ElectricCurrent.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class ElectricCurrent : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Energy.cs
+++ b/Quantities_oM/Attributes/Energy.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Energy : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Force.cs
+++ b/Quantities_oM/Attributes/Force.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Force : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/ForcePerUnitLength.cs
+++ b/Quantities_oM/Attributes/ForcePerUnitLength.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class ForcePerUnitLength : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Frequency.cs
+++ b/Quantities_oM/Attributes/Frequency.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Frequency : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Illuminance.cs
+++ b/Quantities_oM/Attributes/Illuminance.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Illuminace : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Length.cs
+++ b/Quantities_oM/Attributes/Length.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Length : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/LuminousIntensity.cs
+++ b/Quantities_oM/Attributes/LuminousIntensity.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class LuminousIntensity : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Mass.cs
+++ b/Quantities_oM/Attributes/Mass.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Mass : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/MassFraction.cs
+++ b/Quantities_oM/Attributes/MassFraction.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class MassFraction : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Moment.cs
+++ b/Quantities_oM/Attributes/Moment.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Moment : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/MomentPerUnitLength.cs
+++ b/Quantities_oM/Attributes/MomentPerUnitLength.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class MomentPerUnitLength : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Pressure.cs
+++ b/Quantities_oM/Attributes/Pressure.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Pressure : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Ratio.cs
+++ b/Quantities_oM/Attributes/Ratio.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+
+namespace BH.oM.Quantities.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class Ratio : QuantityAttribute
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public override string SIUnit { get; } = "-";
+
+        /***************************************************/
+    }
+}

--- a/Quantities_oM/Attributes/SecondMomentOfArea.cs
+++ b/Quantities_oM/Attributes/SecondMomentOfArea.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class SecondMomentOfArea : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/SectionModulus.cs
+++ b/Quantities_oM/Attributes/SectionModulus.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class SectionModulus : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/ShearModulus.cs
+++ b/Quantities_oM/Attributes/ShearModulus.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class ShearModulus : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Strain.cs
+++ b/Quantities_oM/Attributes/Strain.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Strain : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Stress.cs
+++ b/Quantities_oM/Attributes/Stress.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Stress : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Temperature.cs
+++ b/Quantities_oM/Attributes/Temperature.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Temperature : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/ThermalExpansionCoefficient.cs
+++ b/Quantities_oM/Attributes/ThermalExpansionCoefficient.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class TemperThermalExpansionCoefficientature : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Time.cs
+++ b/Quantities_oM/Attributes/Time.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Time : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/TorsionConstant.cs
+++ b/Quantities_oM/Attributes/TorsionConstant.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class TorsionConstant : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Velocity.cs
+++ b/Quantities_oM/Attributes/Velocity.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Velocity : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/Volume.cs
+++ b/Quantities_oM/Attributes/Volume.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class Volume : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/VolumeticFlowRate.cs
+++ b/Quantities_oM/Attributes/VolumeticFlowRate.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class VolumetricFlowRate : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/WarpingConstant.cs
+++ b/Quantities_oM/Attributes/WarpingConstant.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class WarpingConstant : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Attributes/YoungsModulus.cs
+++ b/Quantities_oM/Attributes/YoungsModulus.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace BH.oM.Quantities.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    [AttributeUsage(AttributeTargets.Property)]
     public class YoungsModulus : QuantityAttribute
     {
         /***************************************************/

--- a/Quantities_oM/Quantities_oM.csproj
+++ b/Quantities_oM/Quantities_oM.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Attributes\Moment.cs" />
     <Compile Include="Attributes\MomentPerUnitLength.cs" />
     <Compile Include="Attributes\Pressure.cs" />
+    <Compile Include="Attributes\Ratio.cs" />
     <Compile Include="Attributes\SecondMomentOfArea.cs" />
     <Compile Include="Attributes\ShearModulus.cs" />
     <Compile Include="Attributes\Strain.cs" />

--- a/Reflection_oM/Attributes/InputAttribute.cs
+++ b/Reflection_oM/Attributes/InputAttribute.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Quantities.Attributes;
 
 namespace BH.oM.Reflection.Attributes
 {
@@ -40,6 +41,7 @@ namespace BH.oM.Reflection.Attributes
 
         public string Description { get; private set; } = "";
 
+        public QuantityAttribute Quantity { get; set; } = null;
 
         /***************************************************/
         /**** Constructors                              ****/
@@ -51,6 +53,17 @@ namespace BH.oM.Reflection.Attributes
             Description = description;
         }
 
+        /***************************************************/
+
+        public InputAttribute(string name, string description, Type quantity)
+        {
+            Name = name;
+            Description = description;
+            if (quantity != null && typeof(QuantityAttribute).IsAssignableFrom(quantity) && quantity != typeof(QuantityAttribute))
+            {
+                Quantity = (QuantityAttribute)Activator.CreateInstance(quantity);
+            }
+        }
 
         /***************************************************/
     }

--- a/Reflection_oM/Attributes/InputAttribute.cs
+++ b/Reflection_oM/Attributes/InputAttribute.cs
@@ -47,15 +47,7 @@ namespace BH.oM.Reflection.Attributes
         /**** Constructors                              ****/
         /***************************************************/
 
-        public InputAttribute(string name, string description)
-        {
-            Name = name;
-            Description = description;
-        }
-
-        /***************************************************/
-
-        public InputAttribute(string name, string description, Type quantity)
+        public InputAttribute(string name, string description, Type quantity = null)
         {
             Name = name;
             Description = description;

--- a/Reflection_oM/Attributes/MultiOutputAttribute.cs
+++ b/Reflection_oM/Attributes/MultiOutputAttribute.cs
@@ -60,6 +60,7 @@ namespace BH.oM.Reflection.Attributes
 
         public MultiOutputAttribute(int index, string name, string description, Type quantity)
         {
+            Index = index;
             Name = name;
             Description = description;
             if (quantity != null && typeof(QuantityAttribute).IsAssignableFrom(quantity) && quantity != typeof(QuantityAttribute))

--- a/Reflection_oM/Attributes/MultiOutputAttribute.cs
+++ b/Reflection_oM/Attributes/MultiOutputAttribute.cs
@@ -49,16 +49,7 @@ namespace BH.oM.Reflection.Attributes
         /**** Constructors                              ****/
         /***************************************************/
 
-        public MultiOutputAttribute(int index, string name, string description)
-        {
-            Index = index;
-            Name = name;
-            Description = description;
-        }
-
-        /***************************************************/
-
-        public MultiOutputAttribute(int index, string name, string description, Type quantity)
+        public MultiOutputAttribute(int index, string name, string description, Type quantity = null)
         {
             Index = index;
             Name = name;

--- a/Reflection_oM/Attributes/MultiOutputAttribute.cs
+++ b/Reflection_oM/Attributes/MultiOutputAttribute.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Quantities.Attributes;
 
 namespace BH.oM.Reflection.Attributes
 {
@@ -42,6 +43,7 @@ namespace BH.oM.Reflection.Attributes
 
         public string Description { get; private set; } = "";
 
+        public QuantityAttribute Quantity { get; set; } = null;
 
         /***************************************************/
         /**** Constructors                              ****/
@@ -54,6 +56,17 @@ namespace BH.oM.Reflection.Attributes
             Description = description;
         }
 
+        /***************************************************/
+
+        public MultiOutputAttribute(int index, string name, string description, Type quantity)
+        {
+            Name = name;
+            Description = description;
+            if (quantity != null && typeof(QuantityAttribute).IsAssignableFrom(quantity) && quantity != typeof(QuantityAttribute))
+            {
+                Quantity = (QuantityAttribute)Activator.CreateInstance(quantity);
+            }
+        }
 
         /***************************************************/
     }

--- a/Reflection_oM/Attributes/OutputAttribute.cs
+++ b/Reflection_oM/Attributes/OutputAttribute.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Quantities.Attributes;
 
 namespace BH.oM.Reflection.Attributes
 {
@@ -40,6 +41,7 @@ namespace BH.oM.Reflection.Attributes
 
         public string Description { get; private set; } = "";
 
+        public QuantityAttribute Quantity { get; set; } = null;
 
         /***************************************************/
         /**** Constructors                              ****/
@@ -58,6 +60,17 @@ namespace BH.oM.Reflection.Attributes
             Description = description;
         }
 
+        /***************************************************/
+
+        public OutputAttribute(string name, string description, Type quantity)
+        {
+            Name = name;
+            Description = description;
+            if (quantity != null && typeof(QuantityAttribute).IsAssignableFrom(quantity) && quantity != typeof(QuantityAttribute))
+            {
+                Quantity = (QuantityAttribute)Activator.CreateInstance(quantity);
+            }
+        }
 
         /***************************************************/
     }

--- a/Reflection_oM/Attributes/OutputAttribute.cs
+++ b/Reflection_oM/Attributes/OutputAttribute.cs
@@ -54,15 +54,7 @@ namespace BH.oM.Reflection.Attributes
 
         /***************************************************/
 
-        public OutputAttribute(string name, string description)
-        {
-            Name = name;
-            Description = description;
-        }
-
-        /***************************************************/
-
-        public OutputAttribute(string name, string description, Type quantity)
+        public OutputAttribute(string name, string description, Type quantity = null)
         {
             Name = name;
             Description = description;

--- a/Reflection_oM/Reflection_oM.csproj
+++ b/Reflection_oM/Reflection_oM.csproj
@@ -63,6 +63,10 @@
       <Name>BHoM</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\Quantities_oM\Quantities_oM.csproj">
+      <Project>{2a5d5a00-d404-4f7e-b771-2fc837145361}</Project>
+      <Name>Quantities_oM</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #683 

<!-- Add short description of what has been fixed -->

Adding Quantity attributes to input and output attributes. This will let us decorate input parameters and output parameters by the use of `typeof(Length)` for example.

Reason for accepting type rather than a Quantity attribute in the constructor is due to limitations on what types that can be passed to a Attribute constructor. @adecler Good to check with you if you see any problems with this?
This will mean that we will lose typestrongness but the syntax will actually look better, `typeof(Length)` over `new Length()`.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->