### PR TITLE
Quantities_oM: Adding mass per unit area and mass per unit length

### DIFF
--- a/Quantities_oM/Attributes/MassPerUnitArea.cs
+++ b/Quantities_oM/Attributes/MassPerUnitArea.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+
+namespace BH.oM.Quantities.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class MassPerUnitArea : QuantityAttribute
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public override int M { get; } = 1;
+
+        public override int L { get; } = -2;
+
+        public override string SIUnit { get; } = "kg/m²";
+
+        /***************************************************/
+    }
+}
+

--- a/Quantities_oM/Attributes/MassPerUnitLength.cs
+++ b/Quantities_oM/Attributes/MassPerUnitLength.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+
+namespace BH.oM.Quantities.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class MassPerUnitLength : QuantityAttribute
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public override int M { get; } = 1;
+
+        public override int L { get; } = -1;
+
+        public override string SIUnit { get; } = "kg/m";
+
+        /***************************************************/
+    }
+}
+

--- a/Quantities_oM/Quantities_oM.csproj
+++ b/Quantities_oM/Quantities_oM.csproj
@@ -59,6 +59,8 @@
     <Compile Include="Attributes\LuminousIntensity.cs" />
     <Compile Include="Attributes\Mass.cs" />
     <Compile Include="Attributes\MassFraction.cs" />
+    <Compile Include="Attributes\MassPerUnitArea.cs" />
+    <Compile Include="Attributes\MassPerUnitLength.cs" />
     <Compile Include="Attributes\Moment.cs" />
     <Compile Include="Attributes\MomentPerUnitLength.cs" />
     <Compile Include="Attributes\Pressure.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #705 

<!-- Add short description of what has been fixed -->

As titles says, adding two missing quantity attributes.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->