### PR TITLE
Structure_oM: Add full compliment of strains to BarStrain and update BarResult descriptions

### DIFF
--- a/Structure_oM/Results/Bar Results/BarForce.cs
+++ b/Structure_oM/Results/Bar Results/BarForce.cs
@@ -33,7 +33,7 @@ namespace BH.oM.Structure.Results
         /***************************************************/
 
         [Force]
-        [Description("Axial/Normal force of the bar. Positive for tension, negative for compression.")]
+        [Description("Axial force along the local x-axis. Positive for tension, negative for compression.")]
         public double FX { get; set; } = 0.0;
 
         [Force]

--- a/Structure_oM/Results/Bar Results/BarStrain.cs
+++ b/Structure_oM/Results/Bar Results/BarStrain.cs
@@ -33,7 +33,7 @@ namespace BH.oM.Structure.Results
         /***************************************************/
 
         [Strain]
-        [Description("Axial strain induced by an axial force along the Bar axis. Positive for tension, negative for compression.")]
+        [Description("Axial strain induced by an axial force along the Bar axis. Positive for elongation, negative for contraction.")]
         public double Axial { get; set; } = 0.0;
 
         [Strain]

--- a/Structure_oM/Results/Bar Results/BarStrain.cs
+++ b/Structure_oM/Results/Bar Results/BarStrain.cs
@@ -33,7 +33,7 @@ namespace BH.oM.Structure.Results
         /***************************************************/
 
         [Strain]
-        [Description("Axial strain induced by force along the Bar axis. Positive for tension, negative for compression.")]
+        [Description("Axial strain induced by an axial force along the Bar axis. Positive for tension, negative for compression.")]
         public double Axial { get; set; } = 0.0;
 
         [Strain]

--- a/Structure_oM/Results/Bar Results/BarStrain.cs
+++ b/Structure_oM/Results/Bar Results/BarStrain.cs
@@ -33,9 +33,40 @@ namespace BH.oM.Structure.Results
         /***************************************************/
 
         [Strain]
-        public double Axial { get; set; }
+        [Description("Axial strain induced by force along the Bar axis. Positive for tension, negative for compression.")]
+        public double Axial { get; set; } = 0.0;
 
-        //TODO: Complete class with additional strains
+        [Strain]
+        [Description("Shear strain along the local y-axis. Generally minor axis shear strain.")]
+        public double ShearY { get; set; } = 0.0;
+
+        [Strain]
+        [Description("Shear strain along the local z-axis. Generally major axis shear strain.")]
+        public double ShearZ { get; set; } = 0.0;
+
+        [Strain]
+        [Description("Strain induced by bending about the local y-axis at the 'uppermost' extreme fiber. Generally the major axis bending strains in one of the extreme fibers.")]
+        public double BendingY_Top { get; set; } = 0.0;
+
+        [Strain]
+        [Description("Strain induced by bending about the local y-axis at the 'lowermost' extreme fiber. Generally the major axis bending strains in one of the extreme fibers.")]
+        public double BendingY_Bot { get; set; } = 0.0;
+
+        [Strain]
+        [Description("Strain induced by bending about the local z-axis at the 'uppermost' extreme fiber. Generally the minor axis bending strains in one of the extreme fibers.")]
+        public double BendingZ_Top { get; set; } = 0.0;
+
+        [Strain]
+        [Description("Strain induced by bending about the local z-axis at the 'lowermost' extreme fiber. Generally the minor axis bending strains in one of the extreme fibers.")]
+        public double BendingZ_Bot { get; set; } = 0.0;
+
+        [Strain]
+        [Description("Worst case tensile axial strain from combined axial and bending in two directions.")]
+        public double CombAxialBendingPos { get; set; } = 0.0;
+
+        [Strain]
+        [Description("Worst case compressive axial strain from combined axial and bending in two directions.")]
+        public double CombAxialBendingNeg { get; set; } = 0.0;
 
         /***************************************************/
     }

--- a/Structure_oM/Results/Bar Results/BarStrain.cs
+++ b/Structure_oM/Results/Bar Results/BarStrain.cs
@@ -61,11 +61,11 @@ namespace BH.oM.Structure.Results
         public double BendingZ_Bot { get; set; } = 0.0;
 
         [Strain]
-        [Description("Worst case tensile axial strain from combined axial and bending in two directions.")]
+        [Description("Worst case elongation (axial strain) from combined axial and bending in two directions.")]
         public double CombAxialBendingPos { get; set; } = 0.0;
 
         [Strain]
-        [Description("Worst case compressive axial strain from combined axial and bending in two directions.")]
+        [Description("Worst case contraction (axial strain) from combined axial and bending in two directions.")]
         public double CombAxialBendingNeg { get; set; } = 0.0;
 
         /***************************************************/

--- a/Structure_oM/Results/Bar Results/BarStress.cs
+++ b/Structure_oM/Results/Bar Results/BarStress.cs
@@ -33,7 +33,7 @@ namespace BH.oM.Structure.Results
         /***************************************************/
 
         [Stress]
-        [Description("Axial stress induced by normal force in the Bar. Positive for tension, negative for compression.")]
+        [Description("Axial stress along the local x-axis. Positive for tension, negative for compression.")]
         public double Axial { get; set; } = 0.0;
 
         [Stress]

--- a/Structure_oM/Results/Bar Results/BarStress.cs
+++ b/Structure_oM/Results/Bar Results/BarStress.cs
@@ -33,7 +33,7 @@ namespace BH.oM.Structure.Results
         /***************************************************/
 
         [Stress]
-        [Description("Axial stress along the local x-axis. Positive for tension, negative for compression.")]
+        [Description("Axial stress induced by an axial force along the Bar axis. Positive for tension, negative for compression.")]
         public double Axial { get; set; } = 0.0;
 
         [Stress]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #696 
Closes #707 

<!-- Add short description of what has been fixed -->
- Added full compliment of strain results in `BarStrain `to mirror `BarStress`
- Updated description of `BarForce `and `BarStress `to remove any mention of normal force 

### Test files
<!-- Link to test files to validate the proposed changes -->
By inspection.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added full compliment of strain results in `BarStrain `to mirror `BarStress`
- Updated description of `BarForce `and `BarStress `to remove any mention of normal force 
