### PR TITLE
Dimensional_oM: Add Description Attributes to IElement Interfaces

### DIFF
--- a/Dimensional_oM/IElement.cs
+++ b/Dimensional_oM/IElement.cs
@@ -25,11 +25,10 @@ using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
-    [Description("An Interface for the Spatial IElements." +
-                 "This Interface should not be inherited directly, only through its sub Interfaces." +
-                 "That is because every method accepting IElement assumes that it's one of the sub-ones.")]
+    [Description("The common base interface for all the Spatial Dimensional Objects." +
+                 "This interface should not be implemented directly, only through its sub-interfaces." +
+                 "Methods operating on IElement assume a specific implementation of one or other of the sub-interfaces (i.e. IElement0D, IElement1D, IElement2D)")]
     public interface IElement : IObject
     {
     }
 }
-

--- a/Dimensional_oM/IElement.cs
+++ b/Dimensional_oM/IElement.cs
@@ -21,9 +21,13 @@
  */
 
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
+    [Description("An Interface for the Spatial IElements." +
+                 "This Interface should not be inherited directly, only through its sub Interfaces." +
+                 "That is because every method accepting IElement assumes that it's one of the sub-ones.")]
     public interface IElement : IObject
     {
     }

--- a/Dimensional_oM/IElement0D.cs
+++ b/Dimensional_oM/IElement0D.cs
@@ -21,9 +21,13 @@
  */
 
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
+    [Description("A Interface which exposes spatial operations to a Point based Element. /n" +
+                 "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
+                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties.")]
     public interface IElement0D : IElement
     {
     }

--- a/Dimensional_oM/IElement0D.cs
+++ b/Dimensional_oM/IElement0D.cs
@@ -27,7 +27,8 @@ namespace BH.oM.Dimensional
 {
     [Description("A Interface which exposes spatial operations to a Point based Element. /n" +
                  "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
-                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties.")]
+                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
+                 "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement0D : IElement
     {
     }

--- a/Dimensional_oM/IElement0D.cs
+++ b/Dimensional_oM/IElement0D.cs
@@ -26,7 +26,6 @@ using System.ComponentModel;
 namespace BH.oM.Dimensional
 {
     [Description("Enables geometrical operations to be performed on a Point based spatial element, whilst preserving all other object properties as unchanged. /n" +
-                 "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
                  "Objects implementing this interface will be required to implement some base methods for getting and setting data in a way that maintains the object's other properties." +
                  "Documentation detailing required extension methods can be found here: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement0D : IElement

--- a/Dimensional_oM/IElement0D.cs
+++ b/Dimensional_oM/IElement0D.cs
@@ -25,12 +25,11 @@ using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
-    [Description("A Interface which exposes spatial operations to a Point based Element. /n" +
+    [Description("Enables geometrical operations to be performed on a Point based spatial element, whilst preserving all other object properties as unchanged. /n" +
                  "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
-                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
-                 "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
+                 "Objects implementing this interface will be required to implement some base methods for getting and setting data in a way that maintains the object's other properties." +
+                 "Documentation detailing required extension methods can be found here: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement0D : IElement
     {
     }
 }
-

--- a/Dimensional_oM/IElement0D.cs
+++ b/Dimensional_oM/IElement0D.cs
@@ -26,7 +26,7 @@ using System.ComponentModel;
 namespace BH.oM.Dimensional
 {
     [Description("A Interface which exposes spatial operations to a Point based Element. /n" +
-                 "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
+                 "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
                  "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
                  "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement0D : IElement

--- a/Dimensional_oM/IElement1D.cs
+++ b/Dimensional_oM/IElement1D.cs
@@ -26,7 +26,7 @@ using System.ComponentModel;
 namespace BH.oM.Dimensional
 {
     [Description("A Interface which exposes spatial operations to a ICurve based Element. /n" +
-                 "The Interface's methods will expose the object to spatial operations which will maintain the objects other properties." +
+                 "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
                  "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties.")]
     public interface IElement1D : IElement
     {

--- a/Dimensional_oM/IElement1D.cs
+++ b/Dimensional_oM/IElement1D.cs
@@ -26,7 +26,6 @@ using System.ComponentModel;
 namespace BH.oM.Dimensional
 {
     [Description("Enables geometrical operations to be performed on a Curve based spatial element, whilst preserving all other object properties as unchanged. /n" +
-                 "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
                  "Objects implementing this interface will be required to implement some base methods for getting and setting data in a way that maintains the object's other properties." +
                   "Documentation detailing required extension methods can be found here: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement1D : IElement

--- a/Dimensional_oM/IElement1D.cs
+++ b/Dimensional_oM/IElement1D.cs
@@ -26,7 +26,7 @@ using System.ComponentModel;
 namespace BH.oM.Dimensional
 {
     [Description("A Interface which exposes spatial operations to a ICurve based Element. /n" +
-                 "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
+                 "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
                  "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
                  "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement1D : IElement

--- a/Dimensional_oM/IElement1D.cs
+++ b/Dimensional_oM/IElement1D.cs
@@ -27,7 +27,8 @@ namespace BH.oM.Dimensional
 {
     [Description("A Interface which exposes spatial operations to a ICurve based Element. /n" +
                  "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
-                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties.")]
+                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
+                 "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement1D : IElement
     {
     }

--- a/Dimensional_oM/IElement1D.cs
+++ b/Dimensional_oM/IElement1D.cs
@@ -21,9 +21,13 @@
  */
 
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
+    [Description("A Interface which exposes spatial operations to a ICurve based Element. /n" +
+                 "The Interface's methods will expose the object to spatial operations which will maintain the objects other properties." +
+                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties.")]
     public interface IElement1D : IElement
     {
     }

--- a/Dimensional_oM/IElement1D.cs
+++ b/Dimensional_oM/IElement1D.cs
@@ -25,12 +25,11 @@ using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
-    [Description("A Interface which exposes spatial operations to a ICurve based Element. /n" +
+    [Description("Enables geometrical operations to be performed on a Curve based spatial element, whilst preserving all other object properties as unchanged. /n" +
                  "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
-                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
-                 "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
+                 "Objects implementing this interface will be required to implement some base methods for getting and setting data in a way that maintains the object's other properties." +
+                  "Documentation detailing required extension methods can be found here: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement1D : IElement
     {
     }
 }
-

--- a/Dimensional_oM/IElement2D.cs
+++ b/Dimensional_oM/IElement2D.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
-    [Description("A Interface which exposes spatial operations to a edge curve based Element. /n" +
+    [Description("A Interface which exposes spatial operations to a edge curve based 2-dimensional Element. /n" +
                  "The interface expects the outline to be constructed of IElement1D elements and allows for internal IElement2D elements." +
                  "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
                  "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties.")]

--- a/Dimensional_oM/IElement2D.cs
+++ b/Dimensional_oM/IElement2D.cs
@@ -27,7 +27,7 @@ namespace BH.oM.Dimensional
 {
     [Description("A Interface which exposes spatial operations to a edge curve based 2-dimensional Element. /n" +
                  "The interface expects the outline to be constructed of IElement1D elements and allows for internal IElement2D elements." +
-                 "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
+                 "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
                  "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
                  "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement2D : IElement

--- a/Dimensional_oM/IElement2D.cs
+++ b/Dimensional_oM/IElement2D.cs
@@ -27,7 +27,6 @@ namespace BH.oM.Dimensional
 {
     [Description("Enables geometrical operations to be performed on an edge curve based two-dimensional spatial element, whilst preserving all other object properties as unchanged. /n" +
                  "The interface expects the outline to be constructed of IElement1D elements and allows for internal IElement2D elements." +
-                 "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
                  "Objects implementing this interface will be required to implement some base methods for getting and setting data in a way that maintains the object's other properties." +
                   "Documentation detailing required extension methods can be found here: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement2D : IElement

--- a/Dimensional_oM/IElement2D.cs
+++ b/Dimensional_oM/IElement2D.cs
@@ -21,9 +21,14 @@
  */
 
 using BH.oM.Base;
+using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
+    [Description("A Interface which exposes spatial operations to a edge curve based Element. /n" +
+                 "The interface expects the outline to be constructed of IElement1D elements and allows for internal IElement2D elements." +
+                 "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
+                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties.")]
     public interface IElement2D : IElement
     {
     }

--- a/Dimensional_oM/IElement2D.cs
+++ b/Dimensional_oM/IElement2D.cs
@@ -28,7 +28,8 @@ namespace BH.oM.Dimensional
     [Description("A Interface which exposes spatial operations to a edge curve based 2-dimensional Element. /n" +
                  "The interface expects the outline to be constructed of IElement1D elements and allows for internal IElement2D elements." +
                  "The Interface's methods will expose the object to spatial operations, which can be applyed without modifying the objects other properties." +
-                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties.")]
+                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
+                 "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement2D : IElement
     {
     }

--- a/Dimensional_oM/IElement2D.cs
+++ b/Dimensional_oM/IElement2D.cs
@@ -25,13 +25,12 @@ using System.ComponentModel;
 
 namespace BH.oM.Dimensional
 {
-    [Description("A Interface which exposes spatial operations to a edge curve based 2-dimensional Element. /n" +
+    [Description("Enables geometrical operations to be performed on an edge curve based two-dimensional spatial element, whilst preserving all other object properties as unchanged. /n" +
                  "The interface expects the outline to be constructed of IElement1D elements and allows for internal IElement2D elements." +
                  "The Interface's methods will expose the object to spatial operations, which can be applied without modifying the objects other properties." +
-                 "Objects implementing this Interface will be required to implement some base methods for getting and setting data in a way that maintains the objects other properties." +
-                 "For further instructions refer to the documentation: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
+                 "Objects implementing this interface will be required to implement some base methods for getting and setting data in a way that maintains the object's other properties." +
+                  "Documentation detailing required extension methods can be found here: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods")]
     public interface IElement2D : IElement
     {
     }
 }
-


### PR DESCRIPTION
### Issues addressed by this PR
Closes #712 
The compliance link: https://github.com/BHoM/documentation/wiki/IElement-required-extension-methods
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Realising as I'm doing this that you (@al-fisher ) probably had a different definition for `IElement` as per your [comment here](https://github.com/BHoM/BHoM/pull/704#pullrequestreview-363323984) 
Slightly unsure on how we would like to handle that as `IElement` is currently defined as a Spatial Interface through its extension methods.
We will probably need to add another level of interface, but that will require some more coordination than this PR