### PR TITLE
Base_oM: Base BHoMObject Properties now all Virtual

### DIFF
--- a/BHoM/BHoMObject.cs
+++ b/BHoM/BHoMObject.cs
@@ -31,15 +31,15 @@ namespace BH.oM.Base
         /**** Properties                                ****/
         /***************************************************/
 
-        public Guid BHoM_Guid { get; set; } = Guid.NewGuid();
+        public virtual Guid BHoM_Guid { get; set; } = Guid.NewGuid();
 
-        public string Name { get; set; } = "";
+        public virtual string Name { get; set; } = "";
 
-        public FragmentSet Fragments { get; set; } = new FragmentSet();
+        public virtual FragmentSet Fragments { get; set; } = new FragmentSet();
 
-        public HashSet<string> Tags { get; set; } = new HashSet<string>();
+        public virtual HashSet<string> Tags { get; set; } = new HashSet<string>();
 
-        public Dictionary<string, object> CustomData { get; set; } = new Dictionary<string, object>();
+        public virtual Dictionary<string, object> CustomData { get; set; } = new Dictionary<string, object>();
 
 
         /***************************************************/


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #733 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
You can now override a base property in a child - you can control default and descriptions like this: 

``` C#
public class Human : BHoMObject
    {
        /***************************************************/
        /**** Properties                                ****/
        /***************************************************/

        [Description("This is the name the human goes by. Say hello!")]
        public override string Name { get; set; } = "BrundleFly";

        public List<IHumanRole> Roles { get; set; } = new List<IHumanRole>();        


        /***************************************************/
```
![image](https://user-images.githubusercontent.com/15924573/75994405-d8c35d00-5ef2-11ea-82a8-da8f5a10c210.png)



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Local override of base BHoMObject Properties is now enabled. This is useful where the parent BHoMObject properties are also essential and defining properties for the child object. Allows setting of both context specific defaults and descriptions by the child object. 

### Additional comments
<!-- As required -->
https://github.com/BHoM/BHoM/issues/734 has been raised to replicate across all objects. To be picked up at later date.