### PR TITLE
Data_Engine: Add generic graph query methods

### DIFF
--- a/Data_oM/Data_oM.csproj
+++ b/Data_oM/Data_oM.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Collections\PointMatrix.cs" />
     <Compile Include="Collections\PriorityQueue.cs" />
     <Compile Include="Collections\Table.cs" />
+    <Compile Include="Enums\GraphNodeNeighbours.cs" />
     <Compile Include="Library\Dataset.cs" />
     <Compile Include="Library\Source.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Data_oM/Data_oM.csproj
+++ b/Data_oM/Data_oM.csproj
@@ -51,7 +51,7 @@
     <Compile Include="Collections\PointMatrix.cs" />
     <Compile Include="Collections\PriorityQueue.cs" />
     <Compile Include="Collections\Table.cs" />
-    <Compile Include="Enums\GraphNodeNeighbours.cs" />
+    <Compile Include="Enums\GraphLinkDirection.cs" />
     <Compile Include="Library\Dataset.cs" />
     <Compile Include="Library\Source.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Data_oM/Enums/GraphLinkDirection.cs
+++ b/Data_oM/Enums/GraphLinkDirection.cs
@@ -22,7 +22,7 @@
 
 namespace BH.oM.Data
 {
-    public enum GraphNodeNeighbours
+    public enum GraphLinkDirection
     {
         Incoming = 0,
         Outgoing = 1,

--- a/Data_oM/Enums/GraphNodeNeighbours.cs
+++ b/Data_oM/Enums/GraphNodeNeighbours.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+namespace BH.oM.Data
+{
+    public enum GraphNodeNeighbours
+    {
+        Incoming = 0,
+        Outgoing = 1,
+        Both = 2
+    }
+}


### PR DESCRIPTION
Add an enum to determine `GraphNode` neighbours required for example in `Engine.Neighbours`

### Issues addressed by this PR
Closes #787 
