### PR TITLE
Architecture_oM: Created Occupancy Under Arch oM

### DIFF
--- a/Architecture_oM/Architecture_oM.csproj
+++ b/Architecture_oM/Architecture_oM.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="Elements\Ceiling.cs" />
     <Compile Include="Elements\Grid.cs" />
+    <Compile Include="Elements\Occupancy.cs" />
     <Compile Include="Elements\Roof.cs" />
     <Compile Include="Elements\Room.cs" />
     <Compile Include="Elements\Wall.cs" />

--- a/Architecture_oM/Elements/Occupancy.cs
+++ b/Architecture_oM/Elements/Occupancy.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+
+using BH.oM.Base;
+
+namespace BH.oM.Architecture.Elements
+{
+    public class Occupancy : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+        [Description("The area per person is representative of the square meters each person occupies within the building or space.")]
+        public virtual double AreaPerPerson { get; set; } = 0.0;
+
+        /***************************************************/
+    }
+}


### PR DESCRIPTION
CreatedOccupancyUnderArchoM

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #795 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
![image](https://user-images.githubusercontent.com/34316256/79475450-afa7e900-7fd5-11ea-8bc6-68336c8d7f9c.png)



### Changelog
Added occupancy object under architecture oM
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
This component may be utilised by Environments in vent calculation methods/people gains, for structures live loads or for egress calculations, etc.

Note that we chose to use the property "AreaPerPerson" rather than people per 100m2, so there will be dataset conversion required in the future.