### PR TITLE
Reflection_oM: Adding PreviousVersion attribute for versioning support

### DIFF
--- a/Reflection_oM/Attributes/OldVersionAttribute.cs
+++ b/Reflection_oM/Attributes/OldVersionAttribute.cs
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Reflection.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+    public class OldVersionAttribute : Attribute, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual string OldVersionAsText { get; private set; } = "";
+
+        public virtual string FromVersion { get; private set; } = "1.0.0.0";
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public OldVersionAttribute(string fromVersion, string oldVersionAsText = "")
+        {
+            FromVersion = fromVersion;
+            OldVersionAsText = oldVersionAsText;
+        }
+
+
+
+        /***************************************************/
+    }
+}
+

--- a/Reflection_oM/Attributes/PreviousVersionAttribute.cs
+++ b/Reflection_oM/Attributes/PreviousVersionAttribute.cs
@@ -30,7 +30,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Reflection.Attributes
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor, AllowMultiple = true)]
     public class PreviousVersionAttribute : Attribute, IImmutable
     {
         /***************************************************/

--- a/Reflection_oM/Attributes/PreviousVersionAttribute.cs
+++ b/Reflection_oM/Attributes/PreviousVersionAttribute.cs
@@ -30,7 +30,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Reflection.Attributes
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, AllowMultiple = true)]
     public class PreviousVersionAttribute : Attribute, IImmutable
     {
         /***************************************************/

--- a/Reflection_oM/Attributes/PreviousVersionAttribute.cs
+++ b/Reflection_oM/Attributes/PreviousVersionAttribute.cs
@@ -30,14 +30,14 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Reflection.Attributes
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
-    public class OldVersionAttribute : Attribute, IImmutable
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor)]
+    public class PreviousVersionAttribute : Attribute, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        public virtual string OldVersionAsText { get; private set; } = "";
+        public virtual string PreviousVersionAsText { get; private set; } = "";
 
         public virtual string FromVersion { get; private set; } = "1.0.0.0";
 
@@ -46,10 +46,10 @@ namespace BH.oM.Reflection.Attributes
         /**** Constructors                              ****/
         /***************************************************/
 
-        public OldVersionAttribute(string fromVersion, string oldVersionAsText = "")
+        public PreviousVersionAttribute(string fromVersion, string oldVersionAsText = "")
         {
             FromVersion = fromVersion;
-            OldVersionAsText = oldVersionAsText;
+            PreviousVersionAsText = oldVersionAsText;
         }
 
 

--- a/Reflection_oM/Reflection_oM.csproj
+++ b/Reflection_oM/Reflection_oM.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\AbbreviationAttribute.cs" />
-    <Compile Include="Attributes\OldVersionAttribute.cs" />
+    <Compile Include="Attributes\PreviousVersionAttribute.cs" />
     <Compile Include="Attributes\ToBeRemovedAttribute.cs" />
     <Compile Include="Attributes\ReplacedAttribute.cs" />
     <Compile Include="Attributes\DeprecatedAttribute.cs" />

--- a/Reflection_oM/Reflection_oM.csproj
+++ b/Reflection_oM/Reflection_oM.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\AbbreviationAttribute.cs" />
+    <Compile Include="Attributes\OldVersionAttribute.cs" />
     <Compile Include="Attributes\ToBeRemovedAttribute.cs" />
     <Compile Include="Attributes\ReplacedAttribute.cs" />
     <Compile Include="Attributes\DeprecatedAttribute.cs" />


### PR DESCRIPTION

### Issues addressed by this PR
See https://github.com/BHoM/BHoM_UI/pull/247 for more details

Simply add a new attribute that will enable local versioning as an attribute directly applied to a method or property


### Test files
You will have to try you own here if you want to test. But you probably don't need to as it is just a very simple object definition.

