### PR TITLE
Reflection_oM: Fix invalid IImmutable constructor parameter names

### DIFF
--- a/Reflection_oM/Attributes/DeprecatedAttribute.cs
+++ b/Reflection_oM/Attributes/DeprecatedAttribute.cs
@@ -51,12 +51,12 @@ namespace BH.oM.Reflection.Attributes
         /**** Constructors                              ****/
         /***************************************************/
 
-        public DeprecatedAttribute(string fromVersion, string description = "", Type newType = null, string newMethod = "")
+        public DeprecatedAttribute(string fromVersion, string description = "", Type replacingType = null, string replacingMethod = "")
         {
             Description = description;
             FromVersion = fromVersion;
-            ReplacingType = newType;
-            ReplacingMethod = newMethod;
+            ReplacingType = replacingType;
+            ReplacingMethod = replacingMethod;
         }
 
 

--- a/Reflection_oM/Attributes/ReplacedAttribute.cs
+++ b/Reflection_oM/Attributes/ReplacedAttribute.cs
@@ -50,12 +50,12 @@ namespace BH.oM.Reflection.Attributes
         /**** Constructors                              ****/
         /***************************************************/
 
-        public ReplacedAttribute(string fromVersion, string description = "", Type newType = null, string newMethod = "")
+        public ReplacedAttribute(string fromVersion, string description = "", Type replacingType = null, string replacingMethod = "")
         {
             Description = description;
             FromVersion = fromVersion;
-            ReplacingType = newType;
-            ReplacingMethod = newMethod;
+            ReplacingType = replacingType;
+            ReplacingMethod = replacingMethod;
         }
 
 


### PR DESCRIPTION
### Issues addressed by this PR

Closes #834 

The constructor parameters should be matching the property names and types. This PR fixes that.


### Test files
<!-- Link to test files to validate the proposed changes -->
![image](https://user-images.githubusercontent.com/16853390/80581803-4b0e7480-8a40-11ea-80a8-0d85eb7a7bc1.png)

