### PR TITLE
Diffing_oM: remove CustomData from the default "Ignores" of DiffConfig

### DIFF
--- a/Diffing_oM/DiffConfig.cs
+++ b/Diffing_oM/DiffConfig.cs
@@ -39,9 +39,10 @@ namespace BH.oM.Diffing
 
         public double NumericTolerance { get; set; } = 1e-6;
 
-        [Description("List of strings specifying the names of the properties that should be ignored in the diffing. By default it includes BHoM_Guid, CustomData, Fragments."
-            + "Any property found with a name matching any of this list it will not be considered; this includes any sub-object.")]
-        public List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid", "CustomData" };
+        [Description("List of strings specifying the names of the properties that should be ignored in the diffing.\n" +
+            "This includes any sub-object or sub-property. Any property with a name matching any of this list will be ignored.\n" +
+            "By default it includes `BHoM_Guid`.")]
+        public List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid" };
 
         [Description("Enables the property-level diffing: differences in object properties are stored in the `ModifiedPropsPerObject` dictionary.")]
         public bool EnablePropertyDiffing { get; set; } = true;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

As per title. Useful in the scenario described in: https://github.com/BHoM/Speckle_Toolkit/pull/82#issuecomment-622396529

Closes #845 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Check https://github.com/BHoM/Speckle_Toolkit/pull/82

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
