### PR TITLE
Geometry_oM: Explicit casts for Curves

### DIFF
--- a/Geometry_oM/Curve/NurbsCurve.cs
+++ b/Geometry_oM/Curve/NurbsCurve.cs
@@ -56,8 +56,8 @@ namespace BH.oM.Geometry
         {
             return new NurbsCurve {
                 ControlPoints = new List<Point> { line.Start, line.End },
-                Knots = new List<double> { 1, 1 },
-                Weights = new List<double> { 0, 1 },
+                Knots = new List<double> { 0, 1 },
+                Weights = new List<double> { 1, 1 },
             };
         }
 

--- a/Geometry_oM/Curve/NurbsCurve.cs
+++ b/Geometry_oM/Curve/NurbsCurve.cs
@@ -22,6 +22,8 @@
 
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Linq;
+using System;
 
 namespace BH.oM.Geometry
 {
@@ -44,8 +46,83 @@ namespace BH.oM.Geometry
                      "\nKnot vector length must be equal to or greater than the number of ControlPoints, such that together, the difference in counts defines the order (and degree) of the NurbsCurve." +
                      "\nThe NurbsCurve degree is equal to order plus one.")]
         public virtual List<double> Knots { get; set; } = new List<double>();
-        
+
+
         /***************************************************/
+        /**** Explicit Casting - Special Case           ****/
+        /***************************************************/
+
+        public static explicit operator NurbsCurve(Line line)
+        {
+            return new NurbsCurve {
+                ControlPoints = new List<Point> { line.Start, line.End },
+                Knots = new List<double> { 1, 1 },
+                Weights = new List<double> { 0, 1 },
+            };
+        }
+
+        /***************************************************/
+
+        public static explicit operator NurbsCurve(Polyline polyline)
+        {
+            List<Point> points = polyline.ControlPoints;
+            List<double> weights = polyline.ControlPoints.Select(x => 1.0).ToList();
+            List<double> knots = new List<double> { 0 };
+
+            double t = 0;
+            for (int i = 1; i < points.Count; i++)
+            {
+                Vector v = points[i] - points[i - 1];
+                t += Math.Sqrt(v.X * v.X + v.Y * v.Y + v.Z * v.Z);
+                knots.Add(t);
+            }
+            knots = knots.Select(x => x / t).ToList();
+
+            return new NurbsCurve { ControlPoints = points, Weights = weights, Knots = knots };
+        }
+
+        /***************************************************/
+
+        public static explicit operator NurbsCurve(Ellipse ellipse)
+        {
+
+            Point centre = ellipse.Centre;
+            Vector d1 = ellipse.Radius1 * ellipse.Axis1;
+            Vector d2 = ellipse.Radius2 * ellipse.Axis2;
+            double factor = Math.Cos(Math.PI / 4);
+
+            List<Point> points = new List<Point>
+            {
+                centre + d1,
+                centre + d1 + d2,
+                centre + d2,
+                centre - d1 + d2,
+                centre - d1,
+                centre - d1 - d2,
+                centre - d2,
+                centre + d1 - d2,
+                centre + d1
+            };
+
+            return new NurbsCurve
+            {
+                ControlPoints = points,
+                Knots = new List<double> { 0, 0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1.0, 1.0 },
+                Weights = new List<double> { 1.0, factor, 1.0, factor, 1.0, factor, 1.0, factor, 1.0 }
+            };
+
+        }
+
+        /***************************************************/
+
+        public static explicit operator NurbsCurve(Circle circle)
+        {
+            Ellipse ellipse = (Ellipse)circle;
+            return (NurbsCurve)ellipse;
+        }
+
+        /***************************************************/
+
     }
 }
 

--- a/Geometry_oM/Curve/PolyCurve.cs
+++ b/Geometry_oM/Curve/PolyCurve.cs
@@ -34,7 +34,51 @@ namespace BH.oM.Geometry
 
         [Description("A collection of curves, of any or mixed type, which together define the composite shape.")]
         public virtual List<ICurve> Curves { get; set; } = new List<ICurve>();
-        
+
+        /***************************************************/
+        /**** Explicit Casting                          ****/
+        /***************************************************/
+
+        public static explicit operator PolyCurve(Arc curve)
+        {
+            return new PolyCurve() { Curves = new List<ICurve>() { curve } };
+        }
+
+        /***************************************************/
+
+        public static explicit operator PolyCurve(Circle curve)
+        {
+            return new PolyCurve() { Curves = new List<ICurve>() { curve } };
+        }
+
+        /***************************************************/
+
+        public static explicit operator PolyCurve(Ellipse curve)
+        {
+            return new PolyCurve() { Curves = new List<ICurve>() { curve } };
+        }
+
+        /***************************************************/
+
+        public static explicit operator PolyCurve(Line curve)
+        {
+            return new PolyCurve() { Curves = new List<ICurve>() { curve } };
+        }
+
+        /***************************************************/
+
+        public static explicit operator PolyCurve(NurbsCurve curve)
+        {
+            return new PolyCurve() { Curves = new List<ICurve>() { curve } };
+        }
+
+        /***************************************************/
+
+        public static explicit operator PolyCurve(Polyline curve)
+        {
+            return new PolyCurve() { Curves = new List<ICurve>() { curve } };
+        }
+
         /***************************************************/
     }
 }   

--- a/Geometry_oM/Curve/PolyCurve.cs
+++ b/Geometry_oM/Curve/PolyCurve.cs
@@ -76,7 +76,14 @@ namespace BH.oM.Geometry
 
         public static explicit operator PolyCurve(Polyline curve)
         {
-            return new PolyCurve() { Curves = new List<ICurve>() { curve } };
+            PolyCurve result = new PolyCurve();
+
+            for (int i = 0; i < curve.ControlPoints.Count - 1; i++)
+            {
+                result.Curves.Add(new Line() { Start = curve.ControlPoints[i], End = curve.ControlPoints[i + 1] });
+            }
+
+            return result;
         }
 
         /***************************************************/

--- a/Geometry_oM/Curve/Polyline.cs
+++ b/Geometry_oM/Curve/Polyline.cs
@@ -34,7 +34,17 @@ namespace BH.oM.Geometry
 
         [Description("An ordered set of three-dimensional points defining the curve shape")]
         public virtual List<Point> ControlPoints { get; set; } = new List<Point>();
-        
+
+
+        /***************************************************/
+        /**** Explicit Casting                          ****/
+        /***************************************************/
+
+        public static explicit operator Polyline(Line line)
+        {
+            return new Polyline() { ControlPoints = new List<Point>() { line.Start, line.End } };
+        }
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
Closes #790 
Think I'll leave #789 open as it also details step two, the casts with checks
related to #850 which has the wiki page
<!-- Add short description of what has been fixed -->

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EQBbBPE6BYFBlhJwbJllVxIB_ADwYP4S2qo4S03W9DWiwA?e=4BpRMQ

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `ICurve` to `PolyCurve`
- `Line`, `Polyline`, `Ellipse`, `Circle` to `NurbsCurve`
- `Circle` to `Ellipse`
- `Line` to `Polyline`


### Additional comments
<!-- As required -->

There were mentions about various UI things in the issue #789 which I think was decided as not a problem. But could be worth double checking.