### PR TITLE
Geometry_oM: Add Conditional Explicit Casts Between Curve Types.

### DIFF
--- a/Geometry_oM/Curve/Arc.cs
+++ b/Geometry_oM/Curve/Arc.cs
@@ -95,22 +95,19 @@ namespace BH.oM.Geometry
                 return null;
 
             ICurve c = curve.Curves[0];
-            switch (c.GetType().Name)
-            {
-                case "Arc":
-                    return c as Arc;
-                case "Circle":
-                    Circle circle = c as Circle;
-                    return (Arc)circle;
-                case "Ellipse":
-                    Ellipse ellipse = c as Ellipse;
-                    return (Arc)ellipse;
-                case "PolyCurve":
-                    PolyCurve polyCurve = c as PolyCurve;
-                    return (Arc)polyCurve;
-                default:
-                    return null;
-            }
+            if (c == null)
+                return null;
+            else if (c is Arc)
+                return c as Arc;
+            else if (c is Circle)
+                return (Arc)(c as Circle);
+            else if (c is Ellipse)
+                return (Arc)(c as Ellipse);
+            else if (c is PolyCurve)
+                return (Arc)(c as PolyCurve);
+            else
+                return null;
+
         }
 
         /***************************************************/

--- a/Geometry_oM/Curve/Arc.cs
+++ b/Geometry_oM/Curve/Arc.cs
@@ -95,9 +95,7 @@ namespace BH.oM.Geometry
                 return null;
 
             ICurve c = curve.Curves[0];
-            if (c == null)
-                return null;
-            else if (c is Arc)
+            if (c is Arc)
                 return c as Arc;
             else if (c is Circle)
                 return (Arc)(c as Circle);

--- a/Geometry_oM/Curve/Arc.cs
+++ b/Geometry_oM/Curve/Arc.cs
@@ -48,6 +48,7 @@ namespace BH.oM.Geometry
         [Description("Angle in radians to the end point from the local x-axis, counter clockwise around the local z-axis.")]
         public virtual double EndAngle { get; set; } = 0;
 
+
         /***************************************************/
         /**** Explicit Casting - Special Case           ****/
         /***************************************************/
@@ -84,6 +85,44 @@ namespace BH.oM.Geometry
                 StartAngle = 0,
                 EndAngle = Math.PI * 2
             };
+        }
+
+        /***************************************************/
+
+        public static explicit operator Arc(PolyCurve curve)
+        {
+            if (curve.Curves.Count != 1)
+                return null;
+
+            ICurve c = curve.Curves[0];
+            switch (c.GetType().Name)
+            {
+                case "Arc":
+                    return c as Arc;
+                case "Circle":
+                    Circle circle = c as Circle;
+                    return (Arc)circle;
+                case "Ellipse":
+                    Ellipse ellipse = c as Ellipse;
+                    return (Arc)ellipse;
+                case "PolyCurve":
+                    PolyCurve polyCurve = c as PolyCurve;
+                    return (Arc)polyCurve;
+                default:
+                    return null;
+            }
+        }
+
+        /***************************************************/
+
+        public static explicit operator Arc(Ellipse curve)
+        {
+            Circle circle = (Circle)curve;
+
+            if (circle == null)
+                return null;
+
+            return (Arc)circle;
         }
 
         /***************************************************/

--- a/Geometry_oM/Curve/Circle.cs
+++ b/Geometry_oM/Curve/Circle.cs
@@ -53,22 +53,18 @@ namespace BH.oM.Geometry
                 return null;
             
             ICurve c = curve.Curves[0];
-            switch (c.GetType().Name)
-            {
-                case "Circle":
-                    return c as Circle;
-                case "Arc":
-                    Arc arc = c as Arc;
-                    return (Circle)arc;
-                case "Ellipse":
-                    Ellipse ellipse = c as Ellipse;
-                    return (Circle)ellipse;
-                case "PolyCurve":
-                    PolyCurve polyCurve = c as PolyCurve;
-                    return (Circle)polyCurve;
-                default:
-                    return null;
-            }
+            if (c == null)
+                return null;
+            else if (c is Circle)
+                return c as Circle;
+            else if (c is Arc)
+                return (Circle)(c as Arc);
+            else if (c is Ellipse)
+                return ((Circle)(c as Ellipse));
+            else if (c is PolyCurve)
+                return (Circle)(c as PolyCurve);
+            else
+                return null;
         }
 
         /***************************************************/

--- a/Geometry_oM/Curve/Circle.cs
+++ b/Geometry_oM/Curve/Circle.cs
@@ -42,6 +42,70 @@ namespace BH.oM.Geometry
         [Description("Distance from the Centre to any point on Circle.")]
         public virtual double Radius { get; set; } = 0;
 
+
+        /***************************************************/
+        /**** Explicit Casting - Special Case           ****/
+        /***************************************************/
+
+        public static explicit operator Circle(PolyCurve curve)
+        {
+            if (curve.Curves.Count != 1)
+                return null;
+            
+            ICurve c = curve.Curves[0];
+            switch (c.GetType().Name)
+            {
+                case "Circle":
+                    return c as Circle;
+                case "Arc":
+                    Arc arc = c as Arc;
+                    return (Circle)arc;
+                case "Ellipse":
+                    Ellipse ellipse = c as Ellipse;
+                    return (Circle)ellipse;
+                case "PolyCurve":
+                    PolyCurve polyCurve = c as PolyCurve;
+                    return (Circle)polyCurve;
+                default:
+                    return null;
+            }
+        }
+
+        /***************************************************/
+
+        public static explicit operator Circle(Ellipse curve)
+        {
+            if (System.Math.Abs(curve.Radius1 - curve.Radius2) > Tolerance.Distance)
+                return null;
+
+            Vector x = curve.Axis1;
+            Vector y = curve.Axis2;
+
+            Vector normal = new Vector { X = x.Y * y.Z - x.Z * y.Y, Y = x.Z * y.X - x.X * y.Z, Z = x.X * y.Y - x.Y * y.X };
+
+            return new Circle()
+            {
+                Centre = curve.Centre,
+                Radius = curve.Radius1,
+                Normal = normal,
+            };
+        }
+
+        /***************************************************/
+
+        public static explicit operator Circle(Arc curve)
+        {
+            if (System.Math.Abs((curve.EndAngle - curve.StartAngle) - System.Math.PI * 2) > Tolerance.Distance)
+                return null;
+
+            return new Circle()
+            {
+                Centre = curve.CoordinateSystem.Origin,
+                Normal = curve.CoordinateSystem.Z,
+                Radius = curve.Radius,
+            };
+        }
+
         /***************************************************/
     }
 }

--- a/Geometry_oM/Curve/Circle.cs
+++ b/Geometry_oM/Curve/Circle.cs
@@ -53,9 +53,7 @@ namespace BH.oM.Geometry
                 return null;
             
             ICurve c = curve.Curves[0];
-            if (c == null)
-                return null;
-            else if (c is Circle)
+            if (c is Circle)
                 return c as Circle;
             else if (c is Arc)
                 return (Circle)(c as Arc);

--- a/Geometry_oM/Curve/Ellipse.cs
+++ b/Geometry_oM/Curve/Ellipse.cs
@@ -118,8 +118,10 @@ namespace BH.oM.Geometry
         public static explicit operator Ellipse(Arc curve)
         {
             Circle circle = (Circle)curve;
+
             if (circle == null)
                 return null;
+
             return (Ellipse)circle;
         }
 

--- a/Geometry_oM/Curve/Ellipse.cs
+++ b/Geometry_oM/Curve/Ellipse.cs
@@ -98,9 +98,7 @@ namespace BH.oM.Geometry
                 return null;
 
             ICurve c = curve.Curves[0];
-            if (c == null)
-                return null;
-            else if (c is Ellipse)
+            if (c is Ellipse)
                 return c as Ellipse;
             else if (c is Circle)
                 return (Ellipse)(c as Circle);

--- a/Geometry_oM/Curve/Ellipse.cs
+++ b/Geometry_oM/Curve/Ellipse.cs
@@ -98,22 +98,19 @@ namespace BH.oM.Geometry
                 return null;
 
             ICurve c = curve.Curves[0];
-            switch (c.GetType().Name)
-            {
-                case "Ellipse":
-                    return c as Ellipse;
-                case "Circle":
-                    Circle circle = c as Circle;
-                    return (Ellipse)circle;
-                case "Arc":
-                    Arc arc = c as Arc;
-                    return (Ellipse)arc;
-                case "PolyCurve":
-                    PolyCurve polyCurve = c as PolyCurve;
-                    return (Ellipse)polyCurve;
-                default:
-                    return null;
-            }
+            if (c == null)
+                return null;
+            else if (c is Ellipse)
+                return c as Ellipse;
+            else if (c is Circle)
+                return (Ellipse)(c as Circle);
+            else if (c is Arc)
+                return (Ellipse)(c as Arc);
+            else if (c is PolyCurve)
+                return (Ellipse)(c as PolyCurve);
+            else
+                return null;
+
         }
 
         /***************************************************/

--- a/Geometry_oM/Curve/Ellipse.cs
+++ b/Geometry_oM/Curve/Ellipse.cs
@@ -91,6 +91,42 @@ namespace BH.oM.Geometry
         }
 
         /***************************************************/
+
+        public static explicit operator Ellipse(PolyCurve curve)
+        {
+            if (curve.Curves.Count != 1)
+                return null;
+
+            ICurve c = curve.Curves[0];
+            switch (c.GetType().Name)
+            {
+                case "Ellipse":
+                    return c as Ellipse;
+                case "Circle":
+                    Circle circle = c as Circle;
+                    return (Ellipse)circle;
+                case "Arc":
+                    Arc arc = c as Arc;
+                    return (Ellipse)arc;
+                case "PolyCurve":
+                    PolyCurve polyCurve = c as PolyCurve;
+                    return (Ellipse)polyCurve;
+                default:
+                    return null;
+            }
+        }
+
+        /***************************************************/
+
+        public static explicit operator Ellipse(Arc curve)
+        {
+            Circle circle = (Circle)curve;
+            if (circle == null)
+                return null;
+            return (Ellipse)circle;
+        }
+
+        /***************************************************/
     }
 }
 

--- a/Geometry_oM/Curve/Line.cs
+++ b/Geometry_oM/Curve/Line.cs
@@ -38,7 +38,56 @@ namespace BH.oM.Geometry
 
         [Description("Defines the Line as a ray of infinite extents in both directions")]
         public virtual bool Infinite { get; set; } = false;
-        
+
+
+        /***************************************************/
+        /**** Explicit Casting                          ****/
+        /***************************************************/
+
+        public static explicit operator Line(Polyline line)
+        {
+            if (line.ControlPoints.Count != 2)
+                return null;
+
+            return new Line() { Start = line.ControlPoints[0], End = line.ControlPoints[1] };
+        }
+
+        /***************************************************/
+
+        public static explicit operator Line(NurbsCurve line)
+        {
+            if (line.ControlPoints.Count != 2)
+                return null;
+
+            return new Line() { Start = line.ControlPoints[0], End = line.ControlPoints[1] };
+        }
+
+        /***************************************************/
+
+        public static explicit operator Line(PolyCurve curve)
+        {
+            if (curve.Curves.Count != 1)
+                return null;
+
+            ICurve c = curve.Curves[0];
+            switch (c.GetType().Name)
+            {
+                case "Line":
+                    return c as Line;
+                case "Polyline":
+                    Polyline polyline = c as Polyline;
+                    return (Line)polyline;
+                case "NurbsCurve":
+                    NurbsCurve nurbsCurve = c as NurbsCurve;
+                    return (Line)nurbsCurve;
+                case "PolyCurve":
+                    PolyCurve polyCurve = c as PolyCurve;
+                    return (Line)polyCurve;
+                default:
+                    return null;
+            }
+        }
+
         /***************************************************/
     }
 }

--- a/Geometry_oM/Curve/Line.cs
+++ b/Geometry_oM/Curve/Line.cs
@@ -70,9 +70,7 @@ namespace BH.oM.Geometry
                 return null;
 
             ICurve c = curve.Curves[0];
-            if (c == null)
-                return null;
-            else if (c is Line)
+            if (c is Line)
                 return c as Line;
             else if (c is Polyline)
                 return (Line)(c as Polyline);

--- a/Geometry_oM/Curve/Line.cs
+++ b/Geometry_oM/Curve/Line.cs
@@ -70,22 +70,19 @@ namespace BH.oM.Geometry
                 return null;
 
             ICurve c = curve.Curves[0];
-            switch (c.GetType().Name)
-            {
-                case "Line":
-                    return c as Line;
-                case "Polyline":
-                    Polyline polyline = c as Polyline;
-                    return (Line)polyline;
-                case "NurbsCurve":
-                    NurbsCurve nurbsCurve = c as NurbsCurve;
-                    return (Line)nurbsCurve;
-                case "PolyCurve":
-                    PolyCurve polyCurve = c as PolyCurve;
-                    return (Line)polyCurve;
-                default:
-                    return null;
-            }
+            if (c == null)
+                return null;
+            else if (c is Line)
+                return c as Line;
+            else if (c is Polyline)
+                return (Line)(c as Polyline);
+            else if (c is NurbsCurve)
+                return (Line)(c as NurbsCurve);
+            else if (c is PolyCurve)
+                return (Line)(c as PolyCurve);
+            else
+                return null;
+
         }
 
         /***************************************************/

--- a/Geometry_oM/Curve/NurbsCurve.cs
+++ b/Geometry_oM/Curve/NurbsCurve.cs
@@ -129,9 +129,7 @@ namespace BH.oM.Geometry
                 return null;
 
             ICurve c = curve.Curves[0];
-            if (c == null)
-                return null;
-            else if (c is NurbsCurve)
+            if (c is NurbsCurve)
                 return c as NurbsCurve;
             else if (c is Line)
                 return (NurbsCurve)(c as Line);

--- a/Geometry_oM/Curve/NurbsCurve.cs
+++ b/Geometry_oM/Curve/NurbsCurve.cs
@@ -123,6 +123,38 @@ namespace BH.oM.Geometry
 
         /***************************************************/
 
+        public static explicit operator NurbsCurve(PolyCurve curve)
+        {
+            if (curve.Curves.Count != 1)
+                return null;
+
+            ICurve c = curve.Curves[0];
+            switch (c.GetType().Name)
+            {
+                case "NurbsCurve":
+                    return c as NurbsCurve;
+                case "Line":
+                    Line line = c as Line;
+                    return (NurbsCurve)line;
+                case "Polyline":
+                    Polyline polyline = c as Polyline;
+                    return (NurbsCurve)polyline;
+                case "Ellipse":
+                    Ellipse ellipse = c as Ellipse;
+                    return (NurbsCurve)ellipse;
+                case "Circle":
+                    Circle circle = c as Circle;
+                    return (NurbsCurve)circle;
+                case "PolyCurve":
+                    PolyCurve polyCurve = c as PolyCurve;
+                    return (NurbsCurve)polyCurve;
+                default:
+                    return null;
+            }
+        }
+
+        /***************************************************/
+
     }
 }
 

--- a/Geometry_oM/Curve/NurbsCurve.cs
+++ b/Geometry_oM/Curve/NurbsCurve.cs
@@ -129,28 +129,23 @@ namespace BH.oM.Geometry
                 return null;
 
             ICurve c = curve.Curves[0];
-            switch (c.GetType().Name)
-            {
-                case "NurbsCurve":
-                    return c as NurbsCurve;
-                case "Line":
-                    Line line = c as Line;
-                    return (NurbsCurve)line;
-                case "Polyline":
-                    Polyline polyline = c as Polyline;
-                    return (NurbsCurve)polyline;
-                case "Ellipse":
-                    Ellipse ellipse = c as Ellipse;
-                    return (NurbsCurve)ellipse;
-                case "Circle":
-                    Circle circle = c as Circle;
-                    return (NurbsCurve)circle;
-                case "PolyCurve":
-                    PolyCurve polyCurve = c as PolyCurve;
-                    return (NurbsCurve)polyCurve;
-                default:
-                    return null;
-            }
+            if (c == null)
+                return null;
+            else if (c is NurbsCurve)
+                return c as NurbsCurve;
+            else if (c is Line)
+                return (NurbsCurve)(c as Line);
+            else if (c is Polyline)
+                return (NurbsCurve)(c as Polyline);
+            else if (c is Circle)
+                return (NurbsCurve)(c as Circle);
+            else if (c is Ellipse)
+                return (NurbsCurve)(c as Ellipse);
+            else if (c is PolyCurve)
+                return (NurbsCurve)(c as PolyCurve);
+            else
+                return null;
+            
         }
 
         /***************************************************/

--- a/Geometry_oM/Curve/Polyline.cs
+++ b/Geometry_oM/Curve/Polyline.cs
@@ -93,7 +93,7 @@ namespace BH.oM.Geometry
 
             Polyline result = new Polyline();
 
-            result.ControlPoints.Add(polyLines[0].ControlPoints[0]);
+            result.ControlPoints.AddRange(polyLines[0].ControlPoints);
             for (int i = 1; i < polyLines.Count; i++)
             {
                 // Ensure continious

--- a/Geometry_oM/Curve/Polyline.cs
+++ b/Geometry_oM/Curve/Polyline.cs
@@ -23,6 +23,7 @@
 using System.ComponentModel;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace BH.oM.Geometry
 {
@@ -97,6 +98,11 @@ namespace BH.oM.Geometry
             result.ControlPoints.Add(polyLines[0].ControlPoints[0]);
             for (int i = 1; i < polyLines.Count; i++)
             {
+                // Ensure continious
+                Vector v = polyLines[i].ControlPoints[0] - polyLines[i - 1].ControlPoints.Last();
+                if (Math.Abs(v.X) > Tolerance.Distance || Math.Abs(v.Y) > Tolerance.Distance || Math.Abs(v.Z) > Tolerance.Distance)
+                    return null;
+
                 result.ControlPoints.AddRange(polyLines[i].ControlPoints.Skip(1));
             }
 

--- a/Geometry_oM/Curve/Polyline.cs
+++ b/Geometry_oM/Curve/Polyline.cs
@@ -100,7 +100,7 @@ namespace BH.oM.Geometry
             {
                 // Ensure continious
                 Vector v = polyLines[i].ControlPoints[0] - polyLines[i - 1].ControlPoints.Last();
-                if (Math.Abs(v.X) > Tolerance.Distance || Math.Abs(v.Y) > Tolerance.Distance || Math.Abs(v.Z) > Tolerance.Distance)
+                if (v.X * v.X * + v.Y * v.Y * + v.Z * v.Z < Tolerance.Distance * Tolerance.Distance)
                     return null;
 
                 result.ControlPoints.AddRange(polyLines[i].ControlPoints.Skip(1));

--- a/Geometry_oM/Curve/Polyline.cs
+++ b/Geometry_oM/Curve/Polyline.cs
@@ -67,9 +67,7 @@ namespace BH.oM.Geometry
             List<Polyline> polyLines = new List<Polyline>();
             foreach (ICurve c in polyCurve.Curves)
             {
-                if (c == null)
-                    return null;
-                else if (c is Line)
+                if (c is Line)
                     polyLines.Add((Polyline)(c as Line));
                 else if (c is Polyline)
                     polyLines.Add(c as Polyline);

--- a/Geometry_oM/Curve/Polyline.cs
+++ b/Geometry_oM/Curve/Polyline.cs
@@ -100,7 +100,7 @@ namespace BH.oM.Geometry
             {
                 // Ensure continious
                 Vector v = polyLines[i].ControlPoints[0] - polyLines[i - 1].ControlPoints.Last();
-                if (v.X * v.X * + v.Y * v.Y * + v.Z * v.Z < Tolerance.Distance * Tolerance.Distance)
+                if (v.X * v.X * + v.Y * v.Y * + v.Z * v.Z > Tolerance.Distance * Tolerance.Distance)
                     return null;
 
                 result.ControlPoints.AddRange(polyLines[i].ControlPoints.Skip(1));

--- a/Geometry_oM/Curve/Polyline.cs
+++ b/Geometry_oM/Curve/Polyline.cs
@@ -66,33 +66,30 @@ namespace BH.oM.Geometry
             List<Polyline> polyLines = new List<Polyline>();
             foreach (ICurve c in polyCurve.Curves)
             {
-                switch (c.GetType().Name)
+                if (c == null)
+                    return null;
+                else if (c is Line)
+                    polyLines.Add((Polyline)(c as Line));
+                else if (c is Polyline)
+                    polyLines.Add(c as Polyline);
+                else if (c is NurbsCurve)
                 {
-                    case "NurbsCurve":
-                        NurbsCurve nCurve = c as NurbsCurve;
-                        Polyline pl = (Polyline)nCurve;
-                        if (pl == null)
-                            return null;
-                        else
-                            polyLines.Add(pl);
-                        break;
-                    case "PolyCurve":
-                        PolyCurve pCurve = c as PolyCurve;
-                        pl = (Polyline)pCurve;
-                        if (pl == null)
-                            return null;
-                        else
-                            polyLines.Add(pl);
-                        break;
-                    case "Line":
-                        polyLines.Add((Polyline)(c as Line));
-                        break;
-                    case "Polyline":
-                        polyLines.Add(c as Polyline);
-                        break;
-                    default:
+                    Polyline pl = (Polyline)(c as NurbsCurve);
+                    if (pl == null)
                         return null;
+                    else
+                        polyLines.Add(pl);
                 }
+                else if (c is PolyCurve)
+                {
+                    Polyline pl = (Polyline)(c as PolyCurve);
+                    if (pl == null)
+                        return null;
+                    else
+                        polyLines.Add(pl);
+                }
+                else
+                    return null;
             }
 
             Polyline result = new Polyline();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #789 
There's also the wiki created in #850 

Adds all the explicit casts for curves which has a failure state. 
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
The right hand part of the test, which is testing that nothing breaks to bad (i.e. throws an exception), does not work as the UI does that without https://github.com/BHoM/BHoM_UI/issues/255 s fix, which is handled in https://github.com/BHoM/BHoM_UI/pull/253
https://burohappold.sharepoint.com/:u:/s/BHoM/EUt5Ob8QoL9BtmZo-qw3QvABpAdElVF6QxXzRAR8BmY9lA?e=d6pNRi

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- from `PolyCurve` to any `ICurve`
- from `Ellipse` to `Arc`, `Circle`
- from `Arc` to `Circle`, `Ellipse`
- from `Polyline` to `Line`
- from `NurbsCurve` to `Line`, `Polyline`



### Additional comments
<!-- As required -->
Worth mentioning that the reason it got a bit messy in casting from `PolyCurve` to something is that C# does not support user defined casting from Interfaces. which means that these casts will not be that easily used in the code as one might hope.

So one will only be able to cast specifically from a specific type to another specific type. Not from a interface to a type and expect a `null` if it failed.