### PR TITLE
Data_oM: LogicalNotRequest implemented

### DIFF
--- a/Data_oM/Data_oM.csproj
+++ b/Data_oM/Data_oM.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Collections\VennDiagram.cs" />
     <Compile Include="Requests\IResultRequest.cs" />
     <Compile Include="Requests\LogicalAndRequest.cs" />
+    <Compile Include="Requests\LogicalNotRequest.cs" />
     <Compile Include="Requests\LogicalOrRequest.cs" />
     <Compile Include="Requests\SelectionRequest.cs" />
   </ItemGroup>

--- a/Data_oM/Requests/LogicalNotRequest.cs
+++ b/Data_oM/Requests/LogicalNotRequest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -22,16 +22,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace BH.oM.Data.Requests
 {
-    public interface ILogicalRequest : IRequest
+    [Description("A logical request that inverts the query specified by the input request, i.e. any object that fits this request will be excluded from a pull.")]
+    public class LogicalNotRequest : ILogicalRequest
     {
         /***************************************************/
         /****                Properties                 ****/
         /***************************************************/
-        
-        
+
+        [Description("Request to be inverted, i.e. defining what should be excluded.")]
+        public virtual IRequest Request { get; set; } = null;
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #889

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/Revit_Toolkit/pull/731


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `LogicalNotRequest` has been implemented
- `Requests` property has been removed from `ILogicalRequest`


### Additional comments
<!-- As required -->
- I am not entirely happy about the name of the `Request` property (@IsakNaslundBh neither) - @al-fisher @rwemay do you have any native-speaker suggestions on that one?
- removal of property from an interface should not introduce any versioning issues, as long as the code complies everywhere, right @adecler?