### PR TITLE
Reflection_oM: Adding the IOutputObejct interface

### DIFF
--- a/Reflection_oM/Interface/IOutputObject.cs
+++ b/Reflection_oM/Interface/IOutputObject.cs
@@ -24,7 +24,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Reflection.Interface
 {
-    [Description("Interface to be attached to obejcts that are to be automatically exploded when returned in any UI. Objects implementing this interface will not be constructable from the UI.")]
+    [Description("Interface to be attached to objects that are to be automatically exploded when returned in any UI. Objects implementing this interface will not be constructable from the UI.")]
     public interface IOutputObject
     {
     }

--- a/Reflection_oM/Interface/IOutputObject.cs
+++ b/Reflection_oM/Interface/IOutputObject.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+namespace BH.oM.Reflection.Interface
+{
+    [Description("Interface to be attached to obejcts that are to be automatically exploded when returned in any UI. Objects implementing this interface will not be constructable from the UI.")]
+    public interface IOutputObject
+    {
+    }
+}

--- a/Reflection_oM/Reflection_oM.csproj
+++ b/Reflection_oM/Reflection_oM.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Debugging\Event.cs" />
     <Compile Include="Debugging\EventType.cs" />
     <Compile Include="Debugging\Log.cs" />
+    <Compile Include="Interface\IOutputObject.cs" />
     <Compile Include="Interface\IOutput.cs" />
     <Compile Include="Output.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #893

<!-- Add short description of what has been fixed -->

- Adding interface to be applied to objects that when returned from a method should be automatically exploded.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->