### PR TITLE
LifeCycleAssessment_oM: Fixed Scope Objects 

### DIFF
--- a/LifeCycleAssessment_oM/ScopeObjects/EnclosuresScope.cs
+++ b/LifeCycleAssessment_oM/ScopeObjects/EnclosuresScope.cs
@@ -36,16 +36,16 @@ namespace BH.oM.LifeCycleAssessment
         /***************************************************/
 
         [Description("Enclosure walls are inclusive of the opaque exterior wall assemblies of a building")]
-        public virtual List<IElementM> Walls { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Walls { get; set; } = new List<IBHoMObject>();
         
         [Description("Enclosure curtain walls are large sheets of transparent glazing on the building exterior")]
-        public virtual List<IElementM> CurtainWalls { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> CurtainWalls { get; set; } = new List<IBHoMObject>();
         
         [Description("Enclosure windows are are openings in the building exterior, which consist of framing and glazing")]
-        public virtual List<IElementM> Windows { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Windows { get; set; } = new List<IBHoMObject>();
         
         [Description("Enclosure doors are are openings in the building exterior, which consist of framing and panels")]
-        public virtual List<IElementM> Doors { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Doors { get; set; } = new List<IBHoMObject>();
 
         /***************************************************/
     }

--- a/LifeCycleAssessment_oM/ScopeObjects/FoundationsScope.cs
+++ b/LifeCycleAssessment_oM/ScopeObjects/FoundationsScope.cs
@@ -35,16 +35,16 @@ namespace BH.oM.LifeCycleAssessment
         /***************************************************/
         
         [Description("Foundation footings (or pile caps) are mats below the buildings piles that help to distribute the load from the structure above")]
-        public virtual List<IElementM> Footings { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Footings { get; set; } = new List<IBHoMObject>();
         
         [Description("Foundation piles are structural supports that are driven into the ground below a building to support the building structure")]
-        public virtual List<IElementM> Piles { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Piles { get; set; } = new List<IBHoMObject>();
         
         [Description("Foundation walls are structural walls built below-grade")]
-        public virtual List<IElementM> Walls { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Walls { get; set; } = new List<IBHoMObject>();
         
         [Description("Foundation slabs are structural slabs upon which the building is constructed. This category expects any type of slab, but assumes no construction properties.")]
-        public virtual List<IElementM> Slabs { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Slabs { get; set; } = new List<IBHoMObject>();
 
         /***************************************************/
     }

--- a/LifeCycleAssessment_oM/ScopeObjects/LifeCycleAssessmentScope.cs
+++ b/LifeCycleAssessment_oM/ScopeObjects/LifeCycleAssessmentScope.cs
@@ -35,7 +35,7 @@ namespace BH.oM.LifeCycleAssessment
         /***************************************************/
         public virtual LevelOfDevelopment LevelOfDevelopment { get; set; } = LevelOfDevelopment.Undefined;
         public virtual List<LifeCycleAssessmentPhases> LifeCycleAssessmentPhases { get; set; } = new List<LifeCycleAssessmentPhases>();
-        public virtual PrimaryStructuralMaterial PrimaryStructuralMaterial { get; set; } = PrimaryStructuralMaterial.Undefined;
+        public virtual List<PrimaryStructuralMaterial> PrimaryStructuralMaterial { get; set; } = new List<PrimaryStructuralMaterial>();
         public virtual ProjectArea ProjectArea { get; set; } = ProjectArea.Undefined;
         public virtual ProjectType ProjectType { get; set; } = ProjectType.Undefined;
 

--- a/LifeCycleAssessment_oM/ScopeObjects/MEPScope.cs
+++ b/LifeCycleAssessment_oM/ScopeObjects/MEPScope.cs
@@ -34,28 +34,28 @@ namespace BH.oM.LifeCycleAssessment
         /**** Properties                                ****/
         /***************************************************/
         [Description("MEP Equipment is a machine that processes mechanical, electrical or plumbing loads (eg Fan, Electrical Panel, Pump")]
-        public virtual List<IElementM> Equipment { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Equipment { get; set; } = new List<IBHoMObject>();
         
         [Description("MEP Ductwork is a material (eg sheet metal) that helps to convey airflow from heating, ventilation or cooling systems")]
-        public virtual List<IElementM> Ductwork { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Ductwork { get; set; } = new List<IBHoMObject>();
         
         [Description("MEP Generators are devices that convert mechanical energy to electrical power")]
-        public virtual List<IElementM> Generators { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Generators { get; set; } = new List<IBHoMObject>();
         
         [Description("MEP Conduit is a tube used to route electrical wiring")]
-        public virtual List<IElementM> Conduit { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Conduit { get; set; } = new List<IBHoMObject>();
         
         [Description("MEP Wiring is a flexible conductor of electricity")]
-        public virtual List<IElementM> Wiring { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Wiring { get; set; } = new List<IBHoMObject>();
         
         [Description("MEP Lighting is inclusive of all light fixtures")]
-        public virtual List<IElementM> Lighting { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Lighting { get; set; } = new List<IBHoMObject>();
         
         [Description("MEP Piping is a material (eg copper) that helps to convey fluids (eg water, waste) within a building")]
-        public virtual List<IElementM> Piping { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Piping { get; set; } = new List<IBHoMObject>();
         
         [Description("MEP Batties are energy storage devices (eg photovoltaic panels)")]
-        public virtual List<IElementM> Batteries { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Batteries { get; set; } = new List<IBHoMObject>();
 
         /***************************************************/
     }

--- a/LifeCycleAssessment_oM/ScopeObjects/StructuresScope.cs
+++ b/LifeCycleAssessment_oM/ScopeObjects/StructuresScope.cs
@@ -35,16 +35,16 @@ namespace BH.oM.LifeCycleAssessment
         /**** Properties                                ****/
         /***************************************************/
         [Description("Structural slabs are inclusive of the above-grade structural floors in a building")]
-        public virtual List<IElementM> Slabs { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Slabs { get; set; } = new List<IBHoMObject>();
 
         [Description("Structural core walls are inclusive of the above-grade, structural-grade walls surrounding the core (elevators, building services)")]
-        public virtual List<IElementM> CoreWalls { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> CoreWalls { get; set; } = new List<IBHoMObject>();
 
         [Description("Structural beams are typically horizontal elements that carry the load of floors, roofs, and ceilings")]
-        public virtual List<IElementM> Beams { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Beams { get; set; } = new List<IBHoMObject>();
 
         [Description("Structural columns are typically vertical elements that carry the load of floors, roofs, and ceilings")]
-        public virtual List<IElementM> Columns { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Columns { get; set; } = new List<IBHoMObject>();
 
         /***************************************************/
     }

--- a/LifeCycleAssessment_oM/ScopeObjects/TenantImprovementScope.cs
+++ b/LifeCycleAssessment_oM/ScopeObjects/TenantImprovementScope.cs
@@ -34,25 +34,25 @@ namespace BH.oM.LifeCycleAssessment
         /**** Properties                                ****/
         /***************************************************/
         [Description("Tenant Improvement Ceiling is a material that creates an additional upper interior surface in a room")]
-        public virtual List<IElementM> Ceiling { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Ceiling { get; set; } = new List<IBHoMObject>();
         
         [Description("Tenant Improvements Flooring  is inclusive of the flooring materials placed on top of the structural floor (eg carpet, tile)")]
-        public virtual List<IElementM> Flooring { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Flooring { get; set; } = new List<IBHoMObject>();
         
         [Description("Tenant Improvements Finishes is inclusive of finishes (eg paint)")]
-        public virtual List<IElementM> Finishes { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Finishes { get; set; } = new List<IBHoMObject>();
         
         [Description("Tenant Improvements Interior Glazing is inclusive of windows in the interior of the building")]
-        public virtual List<IElementM> InteriorGlazing { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> InteriorGlazing { get; set; } = new List<IBHoMObject>();
         
         [Description("Tenant Improvements Furniture includes furnishings (eg tables, chairs, desks)")]
-        public virtual List<IElementM> Furniture { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> Furniture { get; set; } = new List<IBHoMObject>();
         
         [Description("Tenant Improvements Interior Doors includes doors in the interior of the building")]
-        public virtual List<IElementM> InteriorDoors { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> InteriorDoors { get; set; } = new List<IBHoMObject>();
         
         [Description("Tenant Improvements Partition Walls includes walls in the interior of the building")]
-        public virtual List<IElementM> PartitionWalls { get; set; } = new List<IElementM>();
+        public virtual List<IBHoMObject> PartitionWalls { get; set; } = new List<IBHoMObject>();
 
         /***************************************************/
     }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #915 (Already closed, follow up fix)

LCA Scopeobjects take a list of IBHoMObjects instead of IElementM's in order to allow for EPD calculation on non-IElementM objects.
