### PR TITLE
Geometry_oM: Add Mesh3D, and Environment Mesh

### DIFF
--- a/Environment_oM/Elements/BoundaryZone.cs
+++ b/Environment_oM/Elements/BoundaryZone.cs
@@ -31,7 +31,7 @@ using BH.oM.Dimensional;
 
 namespace BH.oM.Environment.Elements
 {    
-    [Description("A zone of the external faces of an Enviorment Mesh.")]
+    [Description("A zone of the external faces of an Environment Mesh.")]
     public class BoundaryZone : BHoMObject, IEnvironmentObject
     {
         /***************************************************/

--- a/Environment_oM/Elements/BoundaryZone.cs
+++ b/Environment_oM/Elements/BoundaryZone.cs
@@ -20,36 +20,31 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
+using System;
 using System.Collections.Generic;
+using BH.oM.Geometry;
 using BH.oM.Base;
+using BH.oM.Analytical.Elements;
+using BH.oM.Environment.Fragments;
+using System.ComponentModel;
+using BH.oM.Dimensional;
 
-namespace BH.oM.Geometry
-{
-    [Description("A polygon mesh, defined by a list of triangular or quadrilateral Faces, Cells and their Vertices.")]
-    public class Mesh3D : IGeometry, IImmutable
+namespace BH.oM.Environment.Elements
+{    
+    [Description("A zone of the external faces of an Enviorment Mesh.")]
+    public class BoundaryZone : BHoMObject, IEnvironmentObject
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
-
-        [Description("Defines the three-dimensional Mesh geometry as  X, Y, Z coordinates.")]
-        public virtual IReadOnlyList<Point> Vertices { get; }
-
-        [Description("The list of polygons, defined as corner Point indices referencing the list of Vertices.")]
-        public virtual IReadOnlyList<Face> Faces { get; }
-
-        [Description("A parallel list to the Faces, details the index of the cells which is behind and infront of each Face.")]
-        public virtual IReadOnlyList<CellRelation> CellRelation { get; }
+        
+        [Description("The indecies of the faces in the Mesh3D which this BoundaryZone is refering to.")]
+        public virtual List<int> FaceIndecies { get; set; } = new List<int>();
+        
 
         /***************************************************/
-
-        public Mesh3D(List<Point> vertices, List<Face> faces, List<CellRelation> cellRelation)
-        {
-            Vertices = vertices;
-            Faces = faces;
-            CellRelation = cellRelation;
-        }
     }
+
+    
 }
 

--- a/Environment_oM/Elements/BoundaryZone.cs
+++ b/Environment_oM/Elements/BoundaryZone.cs
@@ -38,8 +38,8 @@ namespace BH.oM.Environment.Elements
         /**** Properties                                ****/
         /***************************************************/
         
-        [Description("The indecies of the faces in the Mesh3D which this BoundaryZone is refering to.")]
-        public virtual List<int> FaceIndecies { get; set; } = new List<int>();
+        [Description("The indices of the faces in the Mesh3D which this BoundaryZone is referring to.")]
+        public virtual List<int> FaceIndices { get; set; } = new List<int>();
         
 
         /***************************************************/
@@ -47,4 +47,3 @@ namespace BH.oM.Environment.Elements
 
     
 }
-

--- a/Environment_oM/Elements/Mesh.cs
+++ b/Environment_oM/Elements/Mesh.cs
@@ -46,21 +46,6 @@ namespace BH.oM.Environment.Elements
 
         /***************************************************/
     }
-    
-    [Description("A zone of the external faces of an Enviorment Mesh.")]
-    public class BoundaryZone : BHoMObject, IEnvironmentObject
-    {
-        /***************************************************/
-        /**** Properties                                ****/
-        /***************************************************/
         
-        [Description("The indecies of the faces in the Mesh3D which this BoundaryZone is refering to.")]
-        public virtual List<int> FaceIndecies { get; set; } = new List<int>();
-        
-
-        /***************************************************/
-    }
-
-    
 }
 

--- a/Environment_oM/Elements/Mesh.cs
+++ b/Environment_oM/Elements/Mesh.cs
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using BH.oM.Geometry;
+using BH.oM.Base;
+using BH.oM.Analytical.Elements;
+using BH.oM.Environment.Fragments;
+using System.ComponentModel;
+using BH.oM.Dimensional;
+
+namespace BH.oM.Environment.Elements
+{
+    [Description("An environment object used to define an volumetric mesh.")]
+    public class Mesh : BHoMObject, IEnvironmentObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Defines the three-dimensional Mesh geometry.")]
+        public virtual Mesh3D Mesh3D { get; set; } = null;
+        
+        [Description("Defines the partition of the meshes external faces.")]
+        public virtual List<BoundaryZone> BounderyZones { get; set; } = new List<BoundaryZone>();
+
+        /***************************************************/
+    }
+    
+    [Description("A zone of the external faces of an Enviorment Mesh.")]
+    public class BoundaryZone : BHoMObject, IEnvironmentObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+        
+        [Description("The indecies of the faces in the Mesh3D which this BoundaryZone is refering to.")]
+        public virtual List<int> FaceIndecies { get; set; } = new List<int>();
+        
+
+        /***************************************************/
+    }
+
+    
+}
+

--- a/Environment_oM/Elements/Mesh.cs
+++ b/Environment_oM/Elements/Mesh.cs
@@ -31,7 +31,7 @@ using BH.oM.Dimensional;
 
 namespace BH.oM.Environment.Elements
 {
-    [Description("An environment object used to define an volumetric mesh.")]
+    [Description("An environment object used to define a volumetric mesh.")]
     public class Mesh : BHoMObject, IEnvironmentObject
     {
         /***************************************************/

--- a/Environment_oM/Environment_oM.csproj
+++ b/Environment_oM/Environment_oM.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Climate\Time.cs" />
     <Compile Include="Climate\Sun.cs" />
     <Compile Include="Elements\Building.cs" />
+    <Compile Include="Elements\BoundaryZone.cs" />
     <Compile Include="Elements\Mesh.cs" />
     <Compile Include="Elements\Edge.cs" />
     <Compile Include="Elements\Enums\BuildingType.cs" />

--- a/Environment_oM/Environment_oM.csproj
+++ b/Environment_oM/Environment_oM.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Climate\Time.cs" />
     <Compile Include="Climate\Sun.cs" />
     <Compile Include="Elements\Building.cs" />
+    <Compile Include="Elements\Mesh.cs" />
     <Compile Include="Elements\Edge.cs" />
     <Compile Include="Elements\Enums\BuildingType.cs" />
     <Compile Include="Elements\Enums\OpeningType.cs" />

--- a/Geometry_oM/Geometry_oM.csproj
+++ b/Geometry_oM/Geometry_oM.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Interface\IGeometry.cs" />
     <Compile Include="Math\IntegrationSlice.cs" />
     <Compile Include="Mesh\Face.cs" />
+    <Compile Include="Mesh\CellRelation.cs" />
     <Compile Include="Mesh\Mesh3D.cs" />
     <Compile Include="Mesh\Mesh.cs" />
     <Compile Include="Misc\BoundingBox.cs" />

--- a/Geometry_oM/Geometry_oM.csproj
+++ b/Geometry_oM/Geometry_oM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -52,6 +52,7 @@
     <Compile Include="Interface\IGeometry.cs" />
     <Compile Include="Math\IntegrationSlice.cs" />
     <Compile Include="Mesh\Face.cs" />
+    <Compile Include="Mesh\Mesh3D.cs" />
     <Compile Include="Mesh\Mesh.cs" />
     <Compile Include="Misc\BoundingBox.cs" />
     <Compile Include="Misc\CompositeGeometry.cs" />
@@ -113,7 +114,7 @@
     <ProjectReference Include="..\Reflection_oM\Reflection_oM.csproj">
       <Project>{29E6DCD7-270A-45CC-AC0B-6C024287645E}</Project>
       <Name>Reflection_oM</Name>
-	</ProjectReference>
+    </ProjectReference>
     <ProjectReference Include="..\Quantities_oM\Quantities_oM.csproj">
       <Project>{2a5d5a00-d404-4f7e-b771-2fc837145361}</Project>
       <Name>Quantities_oM</Name>

--- a/Geometry_oM/Mesh/CellRelation.cs
+++ b/Geometry_oM/Mesh/CellRelation.cs
@@ -25,31 +25,21 @@ using System.Collections.Generic;
 using BH.oM.Base;
 
 namespace BH.oM.Geometry
-{
-    [Description("A polygon mesh, defined by a list of triangular or quadrilateral Faces, Cells and their Vertices.")]
-    public class Mesh3D : IGeometry, IImmutable
+{    
+    [Description("Details the index of the cells which is behind and infront of each Face.")]
+    public class CellRelation : IGeometry
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        [Description("Defines the three-dimensional Mesh geometry as  X, Y, Z coordinates.")]
-        public virtual IReadOnlyList<Point> Vertices { get; }
+        [Description("Index of the cell the Face is connected to which its normal is pointing away from.")]
+        public virtual int FromCell { get; set; } = -1;
 
-        [Description("The list of polygons, defined as corner Point indices referencing the list of Vertices.")]
-        public virtual IReadOnlyList<Face> Faces { get; }
-
-        [Description("A parallel list to the Faces, details the index of the cells which is behind and infront of each Face.")]
-        public virtual IReadOnlyList<CellRelation> CellRelation { get; }
+        [Description("Index of the cell the Face is connected to which its normal is pointing towards.")]
+        public virtual int ToCell { get; set; } = -1;
 
         /***************************************************/
-
-        public Mesh3D(List<Point> vertices, List<Face> faces, List<CellRelation> cellRelation)
-        {
-            Vertices = vertices;
-            Faces = faces;
-            CellRelation = cellRelation;
-        }
     }
 }
 

--- a/Geometry_oM/Mesh/Mesh3D.cs
+++ b/Geometry_oM/Mesh/Mesh3D.cs
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using System.Collections.Generic;
+using BH.oM.Base;
+
+namespace BH.oM.Geometry
+{
+    [Description("A polygon mesh, defined by a list of triangular or quadrilateral Faces, Cells and their Vertices.")]
+    public class Mesh3D : IGeometry, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Defines the three-dimensional Mesh geometry as  X, Y, Z coordinates.")]
+        public virtual IReadOnlyList<Point> Vertices { get; }
+
+        [Description("The list of polygons, defined as corner Point indices referencing the list of Vertices.")]
+        public virtual IReadOnlyList<Face> Faces { get; }
+
+        [Description("A parallel list to the Faces, details the index of the cells which is behind and infront of each Face.")]
+        public virtual IReadOnlyList<CellRelation> CellRelation { get; }
+
+        /***************************************************/
+
+        public Mesh3D(List<Point> vertices, List<Face> faces, List<CellRelation> cellRelation)
+        {
+            Vertices = vertices;
+            Faces = faces;
+            CellRelation = cellRelation;
+        }
+    }
+    
+    [Description("Details the index of the cells which is behind and infront of each Face.")]
+    public class CellRelation : IGeometry
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Index of the cell the Face is connected to which its normal is pointing away from.")]
+        public virtual int FromCell { get; set; } = -1;
+
+        [Description("Index of the cell the Face is connected to which its normal is pointing towards.")]
+        public virtual int ToCell { get; set; } = -1;
+
+        /***************************************************/
+    }
+}
+


### PR DESCRIPTION
### Issues addressed by this PR
Closes #419 

<!-- Add short description of what has been fixed -->
Adds a Mesh3D object in Geometry_oM which contains all the geometrical information to rebuild the data in the issue, and a Environment object which can contain the analytical information.

Opted to mirror the cell handling by OpenFOAM, as defining cells as we define faces was a more annoying conversion (and heavy) which would be were bad if most of the methods will make use of external software's.

Will open some necessary follow up PRs in Engine and Rhino
https://github.com/BHoM/BHoM_Engine/pull/1884
https://github.com/BHoM/Rhinoceros_Toolkit/pull/167

### Test files
<!-- Link to test files to validate the proposed changes -->
Creates the mesh in the issue as a BHoM object
https://burohappold.sharepoint.com/:u:/s/BHoM/ESMAIxGTC_xKiBC65mlFRXcBzjwEe523U98Z6Yjn4mVLdQ?e=AtAxPw

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->