### PR TITLE
Diffing_oM: add "PropertiesToInclude" and max no of DifferentProperties in DiffConfig

### DIFF
--- a/Diffing_oM/Diff.cs
+++ b/Diffing_oM/Diff.cs
@@ -46,7 +46,8 @@ namespace BH.oM.Diffing
 
         public IEnumerable<object> UnchangedObjects { get; }
 
-        [Description("The Key is the modified object hash. The Value is another Dictionary, whose Key is the name of the modified property, while Value.Item1 is the property value in setA, Value.Item2 in setB.")]
+        [Description("The Key is the modified object hash. The Value is another Dictionary, whose Key is the name of the modified property, while Value.Item1 is the property value in setA, Value.Item2 in setB." +
+            "\nThis dictionary may be exploded by using BH.Engine.Diffing.Query.ListModifiedProperties().")]
         public Dictionary<string, Dictionary<string, Tuple<object, object>>> ModifiedPropsPerObject { get; }
 
         [Description("Default diffing settings for this Stream. Hashes of objects contained in this stream will be computed based on these configs.")]

--- a/Diffing_oM/DiffConfig.cs
+++ b/Diffing_oM/DiffConfig.cs
@@ -50,7 +50,11 @@ namespace BH.oM.Diffing
         [Description("List of strings specifying the names of the properties that should be ignored in the diffing." +
             "\nNOTE: This considers ALL properties AND sub-properties. Any property with a name matching any of this list will be ignored." +
             "\nBy default it includes `BHoM_Guid`.")]
-        public virtual List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid" };
+        public virtual List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid", };
+
+        [Description("List of names of the keys of the BHoMObjects' CustomData dictionary that should be ignored by the diffing." +
+            "\nBy default it includes `RenderMesh`.")]
+        public virtual List<string> CustomDataToIgnore { get; set; } = new List<string>() { "RenderMesh" };
 
         [Description("Enables the property-level diffing: differences in object properties are stored in the `ModifiedPropsPerObject` dictionary.")]
         public virtual bool EnablePropertyDiffing { get; set; } = false;

--- a/Diffing_oM/DiffConfig.cs
+++ b/Diffing_oM/DiffConfig.cs
@@ -61,7 +61,7 @@ namespace BH.oM.Diffing
         public virtual int MaxPropertyDifferences { get; set; } = 1000;
 
         [Description("If enabled, the Diff stores also the objects that did not change (`Unchanged` property).")]
-        public virtual bool StoreUnchangedObjects { get; set; } = false;
+        public virtual bool StoreUnchangedObjects { get; set; } = true;
 
         /***************************************************/
     }

--- a/Diffing_oM/DiffConfig.cs
+++ b/Diffing_oM/DiffConfig.cs
@@ -53,7 +53,7 @@ namespace BH.oM.Diffing
         public virtual List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid" };
 
         [Description("Enables the property-level diffing: differences in object properties are stored in the `ModifiedPropsPerObject` dictionary.")]
-        public virtual bool EnablePropertyDiffing { get; set; } = true;
+        public virtual bool EnablePropertyDiffing { get; set; } = false;
 
         [Description("If EnablePropertyDiffing is true, this sets the maximum number of differences to be determine before stopping." +
             "\nUseful to limit the run time." +

--- a/Diffing_oM/DiffConfig.cs
+++ b/Diffing_oM/DiffConfig.cs
@@ -63,12 +63,6 @@ namespace BH.oM.Diffing
         [Description("If enabled, the Diff stores also the objects that did not change (`Unchanged` property).")]
         public virtual bool StoreUnchangedObjects { get; set; } = false;
 
-        [Description("(Optional)Name of the key where the Id of the objects may be found in the BHoMObjects' CustomData." +
-            "\nIf specified, the diff will be attempted using the Ids found there." +
-            "\nE.g. 'Revit_UniqueId' may be used; an id must be stored under object.CustomData['Revit_UniqueId']." +
-            "\nNOTE: Not used (null) by default; the hash of the objects is used instead.")]
-        public virtual string CustomDataIdKey { get; set; } = null;
-
         /***************************************************/
     }
 }

--- a/Diffing_oM/DiffConfig.cs
+++ b/Diffing_oM/DiffConfig.cs
@@ -55,6 +55,10 @@ namespace BH.oM.Diffing
         [Description("Enables the property-level diffing: differences in object properties are stored in the `ModifiedPropsPerObject` dictionary.")]
         public virtual bool EnablePropertyDiffing { get; set; } = false;
 
+        [Description("If no Id or HashFragment is found on the objects, but the input lists have same length and the objects are in the same order," +
+            "\ndiffing is attempted by taking each object one by one. It will be able to tell only if the objects have been modified or not (no new or old).")]
+        public virtual bool AllowOneByOneDiffing { get; set; } = true;
+
         [Description("If EnablePropertyDiffing is true, this sets the maximum number of differences to be determine before stopping." +
             "\nUseful to limit the run time." +
             "\nDefaults to 1000.")]

--- a/Diffing_oM/DiffConfig.cs
+++ b/Diffing_oM/DiffConfig.cs
@@ -1,6 +1,6 @@
 /*	
  * This file is part of the Buildings and Habitats object Model (BHoM)	
- * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.	
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.	
  *	
  * Each contributor holds copyright over their respective contributions.	
  * The project versioning (Git) records all such contribution source information.	
@@ -37,18 +37,37 @@ namespace BH.oM.Diffing
         /**** Properties                                ****/
         /***************************************************/
 
-        public double NumericTolerance { get; set; } = 1e-6;
+        [Description("Tolerance used to determine numerical differences." +
+            "\nDefaults to 1e-6.")]
+        public virtual double NumericTolerance { get; set; } = 1e-6;
 
-        [Description("List of strings specifying the names of the properties that should be ignored in the diffing.\n" +
-            "This includes any sub-object or sub-property. Any property with a name matching any of this list will be ignored.\n" +
-            "By default it includes `BHoM_Guid`.")]
-        public List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid" };
+        [Description("By default, diffing considers all the properties of the objects." +
+            "\nHere you can specify a list of property names. Only the properties with a name matching any of this list will be considered for diffing." +
+            "\nE.g., if you input 'Name' only the differences in terms of name will be returned." +
+            "\nNOTE: these can be only top-level properties of the object (not the sub-properties).")]
+        public virtual List<string> PropertiesToConsider { get; set; } = new List<string>();
+
+        [Description("List of strings specifying the names of the properties that should be ignored in the diffing." +
+            "\nNOTE: This considers ALL properties AND sub-properties. Any property with a name matching any of this list will be ignored." +
+            "\nBy default it includes `BHoM_Guid`.")]
+        public virtual List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid" };
 
         [Description("Enables the property-level diffing: differences in object properties are stored in the `ModifiedPropsPerObject` dictionary.")]
-        public bool EnablePropertyDiffing { get; set; } = true;
+        public virtual bool EnablePropertyDiffing { get; set; } = true;
+
+        [Description("If EnablePropertyDiffing is true, this sets the maximum number of differences to be determine before stopping." +
+            "\nUseful to limit the run time." +
+            "\nDefaults to 1000.")]
+        public virtual int MaxPropertyDifferences { get; set; } = 1000;
 
         [Description("If enabled, the Diff stores also the objects that did not change (`Unchanged` property).")]
-        public bool StoreUnchangedObjects { get; set; } = false;
+        public virtual bool StoreUnchangedObjects { get; set; } = false;
+
+        [Description("(Optional)Name of the key where the Id of the objects may be found in the BHoMObjects' CustomData." +
+            "\nIf specified, the diff will be attempted using the Ids found there." +
+            "\nE.g. 'Revit_UniqueId' may be used; an id must be stored under object.CustomData['Revit_UniqueId']." +
+            "\nNOTE: Not used (null) by default; the hash of the objects is used instead.")]
+        public virtual string CustomDataIdKey { get; set; } = null;
 
         /***************************************************/
     }

--- a/Diffing_oM/DiffConfig.cs
+++ b/Diffing_oM/DiffConfig.cs
@@ -50,7 +50,7 @@ namespace BH.oM.Diffing
         [Description("List of strings specifying the names of the properties that should be ignored in the diffing." +
             "\nNOTE: This considers ALL properties AND sub-properties. Any property with a name matching any of this list will be ignored." +
             "\nBy default it includes `BHoM_Guid`.")]
-        public virtual List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid", };
+        public virtual List<string> PropertiesToIgnore { get; set; } = new List<string>() { "BHoM_Guid" };
 
         [Description("List of names of the keys of the BHoMObjects' CustomData dictionary that should be ignored by the diffing." +
             "\nBy default it includes `RenderMesh`.")]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #836

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/BHoM_Engine/pull/1900

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Adds the option to regulate MaxDifferences as in https://github.com/BHoM/BHoM_Engine/pull/1900
- Adds the option to regulate the PropertiesToInclude as in https://github.com/BHoM/BHoM_Engine/pull/1900