### PR TITLE
Structure_oM: Turn Load<T> into IELementLoad<T>

### DIFF
--- a/Structure_oM/Loads/AreaTemperatureLoad.cs
+++ b/Structure_oM/Loads/AreaTemperatureLoad.cs
@@ -23,11 +23,12 @@
 using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Uniform temperature load for area elements such as Panels and FEMeshes.")]
-    public class AreaTemperatureLoad : Load<IAreaElement>
+    public class AreaTemperatureLoad : BHoMObject, IElementLoad<IAreaElement>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -36,6 +37,18 @@ namespace BH.oM.Structure.Loads
         [Temperature]
         [Description("Uniform change of temperature of the element.")]
         public virtual double TemperatureChange { get; set; } = 0;
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of IAreaElements that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<IAreaElement> Objects { get; set; } = new BHoMGroup<IAreaElement>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/AreaUniformlyDistributedLoad.cs
+++ b/Structure_oM/Loads/AreaUniformlyDistributedLoad.cs
@@ -24,11 +24,12 @@ using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
 using BH.oM.Geometry;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Uniform area load for area elements such as Panels and FEMeshes.")]
-    public class AreaUniformlyDistributedLoad : Load<IAreaElement>  
+    public class AreaUniformlyDistributedLoad : BHoMObject, IElementLoad<IAreaElement>  
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -37,6 +38,18 @@ namespace BH.oM.Structure.Loads
         [Pressure]
         [Description("The force per area to be applied to the elements.")]
         public virtual Vector Pressure { get; set; } = new Vector();
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of IAreaElements that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<IAreaElement> Objects { get; set; } = new BHoMGroup<IAreaElement>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/BarPointLoad.cs
+++ b/Structure_oM/Loads/BarPointLoad.cs
@@ -24,11 +24,12 @@ using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
 using BH.oM.Geometry;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Point load to be applied for Bars, positioned a set distance from the StartNode.")]
-    public class BarPointLoad : Load<Bar>
+    public class BarPointLoad : BHoMObject, IElementLoad<Bar>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -45,6 +46,18 @@ namespace BH.oM.Structure.Loads
         [Force]
         [Description("Magnitude and direction of the Moment. The load requires the Force and/or the Moment Vector to be non-zero to have any effect.")]
         public virtual Vector Moment { get; set; } = new Vector();
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Bars that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Bar> Objects { get; set; } = new BHoMGroup<Bar>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/BarPrestressLoad.cs
+++ b/Structure_oM/Loads/BarPrestressLoad.cs
@@ -23,11 +23,12 @@
 using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Axial prestress load applied to Bars.")]
-    public class BarPrestressLoad : Load<Bar>
+    public class BarPrestressLoad : BHoMObject, IElementLoad<Bar>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -36,6 +37,18 @@ namespace BH.oM.Structure.Loads
         [Force]
         [Description("Prestress force to be applied to the Bar. Positive for tension, negative for compression.")]
         public virtual double Prestress { get; set; } = 0;
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Bars that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Bar> Objects { get; set; } = new BHoMGroup<Bar>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/BarTemperatureLoad.cs
+++ b/Structure_oM/Loads/BarTemperatureLoad.cs
@@ -23,11 +23,12 @@
 using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Uniform temperature load for Bars.")]
-    public class BarTemperatureLoad : Load<Bar>
+    public class BarTemperatureLoad : BHoMObject, IElementLoad<Bar>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -36,6 +37,18 @@ namespace BH.oM.Structure.Loads
         [Temperature]
         [Description("Uniform temperature change of the Bar.")]
         public virtual double TemperatureChange { get; set; } = 0;
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Bars that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Bar> Objects { get; set; } = new BHoMGroup<Bar>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/BarUniformlyDistributedLoad.cs
+++ b/Structure_oM/Loads/BarUniformlyDistributedLoad.cs
@@ -24,11 +24,12 @@ using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Uniformly distributed load applied to Bars. Can be used to apply force and/or moments.")]
-    public class BarUniformlyDistributedLoad : Load<Bar>
+    public class BarUniformlyDistributedLoad : BHoMObject, IElementLoad<Bar>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -41,6 +42,18 @@ namespace BH.oM.Structure.Loads
         [MomentPerUnitLength]
         [Description("Moment per length unit to be applied to the full length of the Bar. The load requires the Force and/or the Moment Vector to be non-zero to have any effect.")]
         public virtual Vector Moment { get; set; } = new Vector();
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Bars that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Bar> Objects { get; set; } = new BHoMGroup<Bar>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/BarVaryingDistributedLoad.cs
+++ b/Structure_oM/Loads/BarVaryingDistributedLoad.cs
@@ -24,11 +24,12 @@ using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Varying distributed load for bar elements. Can be used to apply force and/or moments.")]
-    public class BarVaryingDistributedLoad : Load<Bar>
+    public class BarVaryingDistributedLoad : BHoMObject, IElementLoad<Bar>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -58,6 +59,17 @@ namespace BH.oM.Structure.Loads
         [Description("Direction and magnitude of the moment at the end of the loaded region.")]
         public virtual Vector MomentB { get; set; } = new Vector();
 
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Bars that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Bar> Objects { get; set; } = new BHoMGroup<Bar>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/GravityLoad.cs
+++ b/Structure_oM/Loads/GravityLoad.cs
@@ -28,7 +28,7 @@ using BH.oM.Quantities.Attributes;
 namespace BH.oM.Structure.Loads
 {
     [Description("Gravity load to be applied to elements such as Bars, Panels and FEMeshes.")]
-    public class GravityLoad : Load<BHoMObject>
+    public class GravityLoad : BHoMObject, IElementLoad<BHoMObject>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -36,6 +36,18 @@ namespace BH.oM.Structure.Loads
         
         [Description("The magnitude and direction of gravity. This will be scaled by the gravity constant g in the analysis, which means a load representing gravity should be a Vector with -1 as its Z-component.")]
         public virtual Vector GravityDirection { get; set; } = new Vector { X = 0, Y = 0, Z = -1 };
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of structural elements, Bars and IAreaElements, that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<BHoMObject> Objects { get; set; } = new BHoMGroup<BHoMObject>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/IElementLoad.cs
+++ b/Structure_oM/Loads/IElementLoad.cs
@@ -27,24 +27,15 @@ using System.ComponentModel;
 namespace BH.oM.Structure.Loads
 {
 
-    [Description("Base load class used by all element type loads, such as Bar, Node and Panel loads.")]
-    public abstract class Load<T> : BHoMObject, ILoad where T : IBHoMObject
+    [Description("Base load interface used by all element type loads, such as Bar, Node and Panel loads.")]
+    public interface IElementLoad<T> : IBHoMObject, ILoad where T : IBHoMObject
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        [Description("The Loadcase in which the load is applied.")]
-        public virtual Loadcase Loadcase { get; set; }
-
         [Description("The group of objects that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
-        public virtual BHoMGroup<T> Objects { get; set; } = new BHoMGroup<T>();
-
-        [Description("Defines whether the load is applied in local or global coordinates.")]
-        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
-
-        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
-        public virtual bool Projected { get; set; } = false;
+        BHoMGroup<T> Objects { get; set; }
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/PointAcceleration.cs
+++ b/Structure_oM/Loads/PointAcceleration.cs
@@ -24,11 +24,12 @@ using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Point acceleration load for Nodes. This can be used to apply translational as well as angular acceleration.")]
-    public class PointAcceleration : Load<Node>
+    public class PointAcceleration : BHoMObject, IElementLoad<Node>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -39,6 +40,18 @@ namespace BH.oM.Structure.Loads
 
         [AngularAcceleration]
         public virtual Vector RotationalAcceleration { get; set; } = new Vector();
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Nodes that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Node> Objects { get; set; } = new BHoMGroup<Node>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/PointDisplacement.cs
+++ b/Structure_oM/Loads/PointDisplacement.cs
@@ -24,11 +24,12 @@ using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Point displacement for Nodes. This can be used to apply translation as well as rotation.")]
-    public class PointDisplacement : Load<Node>
+    public class PointDisplacement : BHoMObject, IElementLoad<Node>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -39,6 +40,18 @@ namespace BH.oM.Structure.Loads
 
         [Angle]
         public virtual Vector Rotation { get; set; } = new Vector();
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Nodes that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Node> Objects { get; set; } = new BHoMGroup<Node>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/PointLoad.cs
+++ b/Structure_oM/Loads/PointLoad.cs
@@ -24,11 +24,12 @@ using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Point load for Nodes. This can be used to apply force as well as moment.")]
-    public class PointLoad : Load<Node> 
+    public class PointLoad : BHoMObject, IElementLoad<Node> 
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -39,6 +40,18 @@ namespace BH.oM.Structure.Loads
 
         [Moment]
         public virtual Vector Moment { get;  set; } = new Vector();
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Nodes that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Node> Objects { get; set; } = new BHoMGroup<Node>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/PointVelocity.cs
+++ b/Structure_oM/Loads/PointVelocity.cs
@@ -24,11 +24,12 @@ using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Point velocity load for Nodes. This can be used to apply translational as well as angular velocity.")]
-    public class PointVelocity : Load<Node>
+    public class PointVelocity : BHoMObject, IElementLoad<Node>
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -39,6 +40,18 @@ namespace BH.oM.Structure.Loads
 
         [AngularVelocity]
         public virtual Vector RotationalVelocity { get; set; } = new Vector();
+
+        [Description("The Loadcase in which the load is applied.")]
+        public virtual Loadcase Loadcase { get; set; }
+
+        [Description("The group of Nodes that the load should be applied to. For most analysis packages the objects added here need to be pulled from the analysis package before being assigned to the load.")]
+        public virtual BHoMGroup<Node> Objects { get; set; } = new BHoMGroup<Node>();
+
+        [Description("Defines whether the load is applied in local or global coordinates.")]
+        public virtual LoadAxis Axis { get; set; } = LoadAxis.Global;
+
+        [Description("If true the load is projected to the element. This means that the load will be reduced when its direction is at an angle to the element.")]
+        public virtual bool Projected { get; set; } = false;
 
         /***************************************************/
     }

--- a/Structure_oM/Structure_oM.csproj
+++ b/Structure_oM/Structure_oM.csproj
@@ -77,7 +77,7 @@
     <Compile Include="Loads\GravityLoad.cs" />
     <Compile Include="Loads\ICase.cs" />
     <Compile Include="Loads\ILoad.cs" />
-    <Compile Include="Loads\Load.cs" />
+    <Compile Include="Loads\IElementLoad.cs" />
     <Compile Include="Loads\ContourLoad.cs" />
     <Compile Include="Loads\Loadcase.cs" />
     <Compile Include="Loads\LoadCombination.cs" />

--- a/Structure_oM/Versioning_33.json
+++ b/Structure_oM/Versioning_33.json
@@ -28,4 +28,4 @@
     "BH.oM.Structure.Elements.RigidLink.SecondaryNodes": "BH.oM.Structure.Elements.RigidLink.SlaveNodes"
     }
   }
-
+}

--- a/Structure_oM/Versioning_33.json
+++ b/Structure_oM/Versioning_33.json
@@ -12,8 +12,10 @@
 	"BH.oM.Structure.Elements.FramingElement" : "BH.oM.Physical.Elements.IFramingElement"
 	"BH.oM.Structure.FramingProperties.ConstantFramingElementProperty" : "BH.oM.Physical.FramingProperties.ConstantFramingProperty"
 	"BH.oM.Structure.FramingProperties.IFramingElementProperty" : "BH.oM.Physical.FramingProperties.IFramingElementProperty"
+	"BH.oM.Structure.Loads.Load`1" : "BH.oM.Structure.Loads.IElementLoad`1"
     },
     "ToOld": {
+	"BH.oM.Structure.Loads.IElementLoad`1" : "BH.oM.Structure.Loads.Load`1"
     }
   },
   "Property": {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #946 

<!-- Add short description of what has been fixed -->

Changing the abstract class `Load<T>` into an interface.
Renaming to `IElementLoad<T>` to better highlight intent
As no longer an abstract class but an interface, all properties have been added to all implementing classes and an direct inheritance to BHoMObejct added.

### Test files
<!-- Link to test files to validate the proposed changes -->

Test file testing that the Type component upgrades correctly and that all existing load classes still de-serialise correctly. Please note, for the Type component to upgrade properly, the Versioning_Toolkit needs to be built after this PR.

https://burohappold.sharepoint.com/:f:/s/BHoM/EgYptE6GOE9Hs_xqcghkGWwB7EHdw6KHumPfR6ufZJcleQ?e=B1Lfsv

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->