### PR TITLE
MEP_oM: Fix constructor arguments for DuctSectionProperty

### DIFF
--- a/MEP_oM/SectionProperties/DuctSectionProperty.cs
+++ b/MEP_oM/SectionProperties/DuctSectionProperty.cs
@@ -71,16 +71,16 @@ namespace BH.oM.MEP.SectionProperties
         public virtual double InsulationVoidArea { get; }
 
         //Constructor
-        public DuctSectionProperty(SectionProfile ductProfile, double elementSolidArea, double liningSolidArea, double insulationSolidArea, double elementVoidArea, double liningVoidArea, double insulationVoidArea, double hydralicDiameter, double circularEquivalentDiameter)
+        public DuctSectionProperty(SectionProfile sectionProfile, double elementSolidArea, double liningSolidArea, double insulationSolidArea, double elementVoidArea, double liningVoidArea, double insulationVoidArea, double hydraulicDiameter, double circularEquivalentDiameter)
         {
-            SectionProfile = ductProfile;
+            SectionProfile = sectionProfile;
             ElementSolidArea = elementSolidArea;
             ElementVoidArea = elementVoidArea;
             LiningSolidArea = liningSolidArea;
             LiningVoidArea = liningVoidArea;
             InsulationSolidArea = insulationSolidArea;
             InsulationVoidArea = insulationVoidArea;
-            HydraulicDiameter = hydralicDiameter;
+            HydraulicDiameter = hydraulicDiameter;
             CircularEquivalentDiameter = circularEquivalentDiameter;
         }
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #977

<!-- Add short description of what has been fixed -->

Fix argument names of constructor so they match the property names exactly. Important for serialisation to function.

### Test files
<!-- Link to test files to validate the proposed changes -->

General serialisation test:

https://burohappold.sharepoint.com/:f:/s/BHoM/EobV-zo3k9NCrXrp9WsnwF4BIfg0V4Xx520ZcZL94n2eEQ?e=26tEW2

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->