### PR TITLE
Geometry_oM: Added InterpolationOrder and added shape to constructor for TaperedProfile

### DIFF
--- a/Geometry_oM/ShapeProfiles/TaperedProfile.cs
+++ b/Geometry_oM/ShapeProfiles/TaperedProfile.cs
@@ -38,7 +38,7 @@ namespace BH.oM.Geometry.ShapeProfiles
 
         public virtual List<int> InterpolationOrder { get; set; }
 
-        public virtual ReadOnlyDictionary<decimal, IProfile> Profiles { get; }
+        public virtual ReadOnlyDictionary<double, IProfile> Profiles { get; }
 
         public virtual ReadOnlyCollection<ICurve> Edges { get; }
 
@@ -47,9 +47,9 @@ namespace BH.oM.Geometry.ShapeProfiles
         /**** Constructors                              ****/
         /***************************************************/
 
-        public TaperedProfile(IDictionary<decimal, IProfile> profiles, List<int> interpolationOrder, ShapeType shape)
+        public TaperedProfile(IDictionary<double, IProfile> profiles, List<int> interpolationOrder, ShapeType shape)
         {
-            Profiles = new ReadOnlyDictionary<decimal, IProfile>(profiles);
+            Profiles = new ReadOnlyDictionary<double, IProfile>(profiles);
             Edges = new ReadOnlyCollection<ICurve>(new List<ICurve>());
             InterpolationOrder = interpolationOrder;
             Shape = shape;

--- a/Geometry_oM/ShapeProfiles/TaperedProfile.cs
+++ b/Geometry_oM/ShapeProfiles/TaperedProfile.cs
@@ -36,20 +36,24 @@ namespace BH.oM.Geometry.ShapeProfiles
         /***************************************************/
         public virtual ShapeType Shape { get; } = ShapeType.FreeForm;
 
+        public virtual int InterpolationOrder { get; set; }
+
         public virtual ReadOnlyDictionary<decimal, IProfile> Profiles { get; }
 
         public virtual ReadOnlyCollection<ICurve> Edges { get; }
+
 
         /***************************************************/
         /**** Constructors                              ****/
         /***************************************************/
 
-        public TaperedProfile(IDictionary<decimal, IProfile> profiles)
+        public TaperedProfile(IDictionary<decimal, IProfile> profiles, int interpolationOrder, ShapeType shape)
         {
             Profiles = new ReadOnlyDictionary<decimal, IProfile>(profiles);
             Edges = new ReadOnlyCollection<ICurve>(new List<ICurve>());
+            InterpolationOrder = interpolationOrder;
+            Shape = shape;
         }
-
 
         /***************************************************/
     }

--- a/Geometry_oM/ShapeProfiles/TaperedProfile.cs
+++ b/Geometry_oM/ShapeProfiles/TaperedProfile.cs
@@ -36,7 +36,7 @@ namespace BH.oM.Geometry.ShapeProfiles
         /***************************************************/
         public virtual ShapeType Shape { get; } = ShapeType.FreeForm;
 
-        public virtual int InterpolationOrder { get; set; }
+        public virtual List<int> InterpolationOrder { get; set; }
 
         public virtual ReadOnlyDictionary<decimal, IProfile> Profiles { get; }
 
@@ -47,7 +47,7 @@ namespace BH.oM.Geometry.ShapeProfiles
         /**** Constructors                              ****/
         /***************************************************/
 
-        public TaperedProfile(IDictionary<decimal, IProfile> profiles, int interpolationOrder, ShapeType shape)
+        public TaperedProfile(IDictionary<decimal, IProfile> profiles, List<int> interpolationOrder, ShapeType shape)
         {
             Profiles = new ReadOnlyDictionary<decimal, IProfile>(profiles);
             Edges = new ReadOnlyCollection<ICurve>(new List<ICurve>());


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #990 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
@IsakNaslundBh @JosefTaylor I have changed the input for the positions to `List<double>` as `List<decimal>` was giving me some errors about a cast from `System.Object` to `System.Double` in the BHoM UI.