### PR TITLE
MEP_oM: Added Cable Tray definition

### DIFF
--- a/MEP_oM/ConnectionProperties/CableTrayConnectionProperty.cs
+++ b/MEP_oM/ConnectionProperties/CableTrayConnectionProperty.cs
@@ -20,40 +20,29 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 using BH.oM.Base;
-using BH.oM.Analytical.Elements;
-using BH.oM.MEP.SectionProperties;
-using BH.oM.Dimensional;
-using BH.oM.MEP.ConnectionProperties;
-using BH.oM.Quantities.Attributes;
 
-
-namespace BH.oM.MEP.Elements
+namespace BH.oM.MEP.ConnectionProperties
 {
-    [Description("A Cable Tray object is a passageway which conveys material (typically cables)")]
-    public class CableTray : BHoMObject, ILink<Node>, IElement1D, IElementM
+    [Description("A Cable Tray connection property to store information about its physical connectors.")]
+    public class CableTrayConnectionProperty : BHoMObject, IConnectionProperty
     {
         /***************************************************/
         /****                 Properties                ****/
         /***************************************************/
 
-        [Description("The point at which the Cable Tray object begins.")]
-        public virtual Node StartNode { get; set; } = null;
+        [Description("Whether the start point of the Cable Tray is connected to another segment or not.")]
+        public virtual bool IsStartConnected { get; set; }
 
-        [Description("The point at which the Cable Tray object ends.")]
-        public virtual Node EndNode { get; set; } = null;       
-
-        [Description("The Cable Tray section property defines the shape (rectangular) and its associated properties (height, width, material, thickness/gauge).")]
-        public virtual CableTraySectionProperty SectionProperty { get; set; } = null;
-
-        [Description("The Cable Tray connections properties, such as if it's connected and to what.")]
-        public virtual CableTrayConnectionProperty ConnectionProperty { get; set; } = null;
-
-        [Angle]
-        [Description("This is the Cable Tray's planometric orientation angle (the rotation around its central axis).")]
-        public virtual double OrientationAngle { get; set; } = 0;
+        [Description("Whether the end point of the Cable Tray is connected to another segment or not.")]
+        public virtual bool IsEndConnected { get; set; }
 
         /***************************************************/
     }

--- a/MEP_oM/ConnectionProperties/IConnectionProperty.cs
+++ b/MEP_oM/ConnectionProperties/IConnectionProperty.cs
@@ -28,6 +28,7 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Base;
+using BH.oM.MEP.Elements;
 
 namespace BH.oM.MEP.ConnectionProperties
 {
@@ -35,9 +36,14 @@ namespace BH.oM.MEP.ConnectionProperties
     public interface IConnectionProperty : IBHoMObject
     {
         /***************************************************/
-        /**** Properties                                ****/
+        /****                 Properties                ****/
         /***************************************************/
 
+        [Description("The point at which the Connector object begins.")]
+        Node StartNode { get; set; }
+
+        [Description("The point at which the Connector bject ends.")]
+        Node EndNode { get; set; }
 
         /***************************************************/
     }

--- a/MEP_oM/ConnectionProperties/IConnectionProperty.cs
+++ b/MEP_oM/ConnectionProperties/IConnectionProperty.cs
@@ -20,40 +20,24 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Base;
-using BH.oM.Analytical.Elements;
-using BH.oM.MEP.SectionProperties;
-using BH.oM.Dimensional;
-using BH.oM.MEP.ConnectionProperties;
-using BH.oM.Quantities.Attributes;
 
-
-namespace BH.oM.MEP.Elements
+namespace BH.oM.MEP.ConnectionProperties
 {
-    [Description("A Cable Tray object is a passageway which conveys material (typically cables)")]
-    public class CableTray : BHoMObject, ILink<Node>, IElement1D, IElementM
+    [Description("Base interface for MEP physical connection properties.")]
+    public interface IConnectionProperty : IBHoMObject
     {
         /***************************************************/
-        /****                 Properties                ****/
+        /**** Properties                                ****/
         /***************************************************/
 
-        [Description("The point at which the Cable Tray object begins.")]
-        public virtual Node StartNode { get; set; } = null;
-
-        [Description("The point at which the Cable Tray object ends.")]
-        public virtual Node EndNode { get; set; } = null;       
-
-        [Description("The Cable Tray section property defines the shape (rectangular) and its associated properties (height, width, material, thickness/gauge).")]
-        public virtual CableTraySectionProperty SectionProperty { get; set; } = null;
-
-        [Description("The Cable Tray connections properties, such as if it's connected and to what.")]
-        public virtual CableTrayConnectionProperty ConnectionProperty { get; set; } = null;
-
-        [Angle]
-        [Description("This is the Cable Tray's planometric orientation angle (the rotation around its central axis).")]
-        public virtual double OrientationAngle { get; set; } = 0;
 
         /***************************************************/
     }

--- a/MEP_oM/Elements/CableTray.cs
+++ b/MEP_oM/Elements/CableTray.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+using BH.oM.Base;
+using BH.oM.Analytical.Elements;
+using BH.oM.MEP.SectionProperties;
+using BH.oM.Dimensional;
+using BH.oM.Quantities.Attributes;
+
+
+namespace BH.oM.MEP.Elements
+{
+    [Description("A Cable Tray object is a passageway which conveys material (typically cables)")]
+    public class CableTray : BHoMObject, ILink<Node>, IElement1D, IElementM
+    {
+        /***************************************************/
+        /****                 Properties                ****/
+        /***************************************************/
+
+        [Description("The point at which the Cable Tray object begins.")]
+        public virtual Node StartNode { get; set; } = null;
+
+        [Description("The point at which the Cable Tray object ends.")]
+        public virtual Node EndNode { get; set; } = null;       
+
+        [Description("The Cable Tray section property defines the shape (rectangular) and its associated properties (height, width, material, thickness/gauge).")]
+        public virtual CableTraySectionProperty SectionProperty { get; set; } = null;
+
+        [Angle]
+        [Description("This is the Cable Tray's planometric orientation angle (the rotation around its central axis).")]
+        public virtual double OrientationAngle { get; set; } = 0;
+
+        /***************************************************/
+    }
+}

--- a/MEP_oM/MEP_oM.csproj
+++ b/MEP_oM/MEP_oM.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Elements\CableTray.cs" />
     <Compile Include="Elements\Duct.cs" />
     <Compile Include="Elements\IFlow.cs" />
     <Compile Include="Elements\MechanicalSystem.cs" />
@@ -71,6 +72,7 @@
     <Compile Include="Parts\Fan.cs" />
     <Compile Include="Parts\IPart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SectionProperties\CableTraySectionProperty.cs" />
     <Compile Include="SectionProperties\DuctSectionProperty.cs" />
     <Compile Include="SectionProperties\IFlowSectionProperty.cs" />
     <Compile Include="SectionProperties\PipeSectionProperty.cs" />

--- a/MEP_oM/MEP_oM.csproj
+++ b/MEP_oM/MEP_oM.csproj
@@ -40,6 +40,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConnectionProperties\CableTrayConnectionProperty.cs" />
+    <Compile Include="ConnectionProperties\IConnectionProperty.cs" />
     <Compile Include="Elements\CableTray.cs" />
     <Compile Include="Elements\Duct.cs" />
     <Compile Include="Elements\IFlow.cs" />

--- a/MEP_oM/MEP_oM.csproj
+++ b/MEP_oM/MEP_oM.csproj
@@ -64,6 +64,7 @@
     <Compile Include="MaterialFragments\InsulationMaterial.cs" />
     <Compile Include="MaterialFragments\LiningMaterial.cs" />
     <Compile Include="MaterialFragments\PipeMaterial.cs" />
+    <Compile Include="MaterialFragments\CableTrayMaterial.cs" />
     <Compile Include="MaterialFragments\WireMaterial.cs" />
     <Compile Include="Parts\AirHandlingUnitBase.cs" />
     <Compile Include="Parts\CoolingCoil.cs" />

--- a/MEP_oM/MaterialFragments/CableTrayMaterial.cs
+++ b/MEP_oM/MaterialFragments/CableTrayMaterial.cs
@@ -28,29 +28,11 @@ using System.Text;
 using System.Threading.Tasks;
 
 using BH.oM.Base;
-using BH.oM.MEP.Elements;
 
-namespace BH.oM.MEP.ConnectionProperties
+namespace BH.oM.MEP.MaterialFragments
 {
-    [Description("A Cable Tray connection property to store information about its physical connectors.")]
-    public class CableTrayConnectionProperty : BHoMObject, IConnectionProperty
+    public class CableTrayMaterial : BHoMObject, IMEPMaterial
     {
-        /***************************************************/
-        /****                 Properties                ****/
-        /***************************************************/
-
-        [Description("The point at which the Connector object begins.")]
-        public virtual Node StartNode { get; set; }
-
-        [Description("The point at which the Connector bject ends.")]
-        public virtual Node EndNode { get; set; }
-
-        [Description("Whether the start point of the Cable Tray is connected to another segment or not.")]
-        public virtual bool IsStartConnected { get; set; }
-
-        [Description("Whether the end point of the Cable Tray is connected to another segment or not.")]
-        public virtual bool IsEndConnected { get; set; }       
-
-        /***************************************************/
+        //placeholder to hold cable tray material properties
     }
 }

--- a/MEP_oM/SectionProperties/CableTraySectionProperty.cs
+++ b/MEP_oM/SectionProperties/CableTraySectionProperty.cs
@@ -33,8 +33,8 @@ namespace BH.oM.MEP.SectionProperties
         /****                 Properties                ****/
         /***************************************************/
 
-        [Description("The duct material is the primary material that the duct is composed of (galvanized sheet metal, aluminium)")]
-        public virtual IMEPMaterial CableTrayMaterial { get; set; }     
+        [Description("The cable tray material is the primary material that the it is composed of.")]
+        public virtual IMEPMaterial Material { get; set; }     
 
         [Description("The section profile of the object that will determine its use within a System.")]
         public virtual SectionProfile SectionProfile { get; }
@@ -49,8 +49,9 @@ namespace BH.oM.MEP.SectionProperties
         /****                 Constructor               ****/
         /***************************************************/
         
-        public CableTraySectionProperty(SectionProfile sectionProfile, double elementSolidArea, double elementVoidArea)
+        public CableTraySectionProperty(IMEPMaterial material,SectionProfile sectionProfile, double elementSolidArea, double elementVoidArea)
         {
+            Material = material;
             SectionProfile = sectionProfile;
             ElementSolidArea = elementSolidArea;
             ElementVoidArea = elementVoidArea;            

--- a/MEP_oM/SectionProperties/CableTraySectionProperty.cs
+++ b/MEP_oM/SectionProperties/CableTraySectionProperty.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+using BH.oM.Base;
+using BH.oM.MEP.MaterialFragments;
+
+namespace BH.oM.MEP.SectionProperties
+{
+    public class CableTraySectionProperty : BHoMObject, IImmutable
+    {
+        /***************************************************/
+        /****                 Properties                ****/
+        /***************************************************/
+
+        [Description("The duct material is the primary material that the duct is composed of (galvanized sheet metal, aluminium)")]
+        public virtual IMEPMaterial CableTrayMaterial { get; set; }     
+
+        [Description("The section profile of the object that will determine its use within a System.")]
+        public virtual SectionProfile SectionProfile { get; }
+
+        [Description("This area takes the element's thickness into account to determine the actual area of the 'solid' portion of the ShapeProfile.")]
+        public virtual double ElementSolidArea { get; }
+
+        [Description("The interior area within the element's shapeProfile. This corresponds to the actual open area less any material thickness.")]
+        public virtual double ElementVoidArea { get; }
+
+        /***************************************************/
+        /****                 Constructor               ****/
+        /***************************************************/
+        
+        public CableTraySectionProperty(SectionProfile sectionProfile, double elementSolidArea, double elementVoidArea)
+        {
+            SectionProfile = sectionProfile;
+            ElementSolidArea = elementSolidArea;
+            ElementVoidArea = elementVoidArea;            
+        }
+
+        /***************************************************/
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
Closes #997 

<!-- Add short description of what has been fixed -->
Added the definition for Cable Tray and its `SectionProperty` equivalent.

### Test files
Test file [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/MEP_oM/Issue997-Add%20Cable%20Tray%20definition?csf=1&web=1&e=p8R7e7). No instructions needed.


### Changelog
Added new object `BH.oM.MEP.Elements.CableTray` and `BH.oM.MEP.SectionProperties.CableTraySectionProperty`.


### Additional comments
Within `CableTraySectionProperty` the property `MEPMaterial` has been kept, but no support to it has been added in `IMEPMaterial`, as material is mostly irrelevant (I think) to cable trays holding cables. 