### PR TITLE
Reflection_oM: Adding attributes to better control auto-create components

### DIFF
--- a/Reflection_oM/Attributes/DefaultValueWarningAttribute.cs
+++ b/Reflection_oM/Attributes/DefaultValueWarningAttribute.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Reflection.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DefaultValueWarningAttribute : Attribute, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual string Warning { get; private set; } = "";
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public DefaultValueWarningAttribute(string warning)
+        {
+            Warning = warning;
+        }
+
+
+
+        /***************************************************/
+    }
+}
+

--- a/Reflection_oM/Attributes/DefaultValueWarningAttribute.cs
+++ b/Reflection_oM/Attributes/DefaultValueWarningAttribute.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -31,6 +32,7 @@ using System.Threading.Tasks;
 namespace BH.oM.Reflection.Attributes
 {
     [AttributeUsage(AttributeTargets.Property)]
+    [Description("Warning to be generated when an instance of the containing class is generated with this property set to its default value.")]
     public class DefaultValueWarningAttribute : Attribute, IImmutable
     {
         /***************************************************/

--- a/Reflection_oM/Attributes/DoNotAutoCreateAttribute.cs
+++ b/Reflection_oM/Attributes/DoNotAutoCreateAttribute.cs
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Reflection.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class DoNotAutoCreateAttribute : Attribute, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public DoNotAutoCreateAttribute()
+        {
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Reflection_oM/Attributes/NoAutoConstructorAttribute.cs
+++ b/Reflection_oM/Attributes/NoAutoConstructorAttribute.cs
@@ -31,7 +31,7 @@ using System.Threading.Tasks;
 namespace BH.oM.Reflection.Attributes
 {
     [AttributeUsage(AttributeTargets.Class)]
-    public class DoNotAutoCreateAttribute : Attribute, IImmutable
+    public class NoAutoConstructorAttribute : Attribute, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -42,7 +42,7 @@ namespace BH.oM.Reflection.Attributes
         /**** Constructors                              ****/
         /***************************************************/
 
-        public DoNotAutoCreateAttribute()
+        public NoAutoConstructorAttribute()
         {
         }
 

--- a/Reflection_oM/Attributes/NoAutoConstructorAttribute.cs
+++ b/Reflection_oM/Attributes/NoAutoConstructorAttribute.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -31,6 +32,7 @@ using System.Threading.Tasks;
 namespace BH.oM.Reflection.Attributes
 {
     [AttributeUsage(AttributeTargets.Class)]
+    [Description("Prevents an auto-constructor component to be available in the UI for the targeted class. This means that `Engine.Create` methods will be the only option to generate instances of that class in the UI.")]
     public class NoAutoConstructorAttribute : Attribute, IImmutable
     {
         /***************************************************/

--- a/Reflection_oM/Attributes/RequiredAttribute.cs
+++ b/Reflection_oM/Attributes/RequiredAttribute.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -31,6 +32,7 @@ using System.Threading.Tasks;
 namespace BH.oM.Reflection.Attributes
 {
     [AttributeUsage(AttributeTargets.Property)]
+    [Description("Marks a property as mandatory input when creating an instance of its containing class.")]
     public class RequiredAttribute : Attribute, IImmutable
     {
         /***************************************************/

--- a/Reflection_oM/Attributes/RequiredAttribute.cs
+++ b/Reflection_oM/Attributes/RequiredAttribute.cs
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Reflection.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class RequiredAttribute : Attribute, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public RequiredAttribute()
+        {
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Reflection_oM/Reflection_oM.csproj
+++ b/Reflection_oM/Reflection_oM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -42,10 +42,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\AbbreviationAttribute.cs" />
-    <Compile Include="Attributes\PreviousVersionAttribute.cs" />
-    <Compile Include="Attributes\ToBeRemovedAttribute.cs" />
-    <Compile Include="Attributes\ReplacedAttribute.cs" />
     <Compile Include="Attributes\DeprecatedAttribute.cs" />
+    <Compile Include="Attributes\PreviousVersionAttribute.cs" />
+    <Compile Include="Attributes\DefaultValueWarningAttribute.cs" />
+    <Compile Include="Attributes\ToBeRemovedAttribute.cs" />
+    <Compile Include="Attributes\RequiredAttribute.cs" />
+    <Compile Include="Attributes\ReplacedAttribute.cs" />
+    <Compile Include="Attributes\DoNotAutoCreateAttribute.cs" />
     <Compile Include="Attributes\InputAttribute.cs" />
     <Compile Include="Attributes\InputFromProperty.cs" />
     <Compile Include="Attributes\MultiOutputAttribute.cs" />

--- a/Reflection_oM/Reflection_oM.csproj
+++ b/Reflection_oM/Reflection_oM.csproj
@@ -48,7 +48,7 @@
     <Compile Include="Attributes\ToBeRemovedAttribute.cs" />
     <Compile Include="Attributes\RequiredAttribute.cs" />
     <Compile Include="Attributes\ReplacedAttribute.cs" />
-    <Compile Include="Attributes\DoNotAutoCreateAttribute.cs" />
+    <Compile Include="Attributes\NoAutoConstructorAttribute.cs" />
     <Compile Include="Attributes\InputAttribute.cs" />
     <Compile Include="Attributes\InputFromProperty.cs" />
     <Compile Include="Attributes\MultiOutputAttribute.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #731
Closes #883 

Also helps with https://github.com/BHoM/BHoM_UI/issues/205

This provides the 3 attributes we agreed on when talking about improving the control of the auto-constructor components. 
- Required properties
- Classes that should not have an auto-constructor (because they have a Create method in the engine and the two cannot coexist).
- Warning on the component when the default value of a property is used (spoiler alter, I actually intend to make it a not and not a warning to help OCD people like me that cannot stand for a component to stay orange).

### Test files
Not much to test for now. It is more a matter of agreeing with the definition I created here.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
I am aware that there is plan to migrate the attributes from the reflection engine to the base engine (see https://github.com/BHoM/BHoM_Engine/issues/1645). So I could have create those new attributes in the base already but decided not to in order to keep things tidy.