### PR TITLE
Geometry_oM: Addition of Volume as a Get only Property to BoundaryRepresentation

### DIFF
--- a/Geometry_oM/Solid/BoundaryRepresentation.cs
+++ b/Geometry_oM/Solid/BoundaryRepresentation.cs
@@ -25,6 +25,7 @@ using System.ComponentModel;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
+using BH.oM.Quantities.Attributes;
 
 namespace BH.oM.Geometry
 {
@@ -38,13 +39,18 @@ namespace BH.oM.Geometry
         [Description("List of ISurfaces must form a closed volume - checks and guarantees to be performed at conversion")]
         public virtual ReadOnlyCollection<ISurface> Surfaces { get; }
 
+        [Volume]
+        [Description("The enclosed volume created by the boundary surfaces. Property is set where available at conversion. If unavailable, or invalidated, will read NaN (not a number)")]
+        public virtual double Volume { get; } = double.NaN;
+
         /***************************************************/
         /**** Constructors                              ****/
         /***************************************************/
 
-        public BoundaryRepresentation(IEnumerable<ISurface> surfaces)
+        public BoundaryRepresentation(IEnumerable<ISurface> surfaces, double volume)
         {
             Surfaces = new ReadOnlyCollection<ISurface>(surfaces.ToList());
+            Volume = volume;
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/2058 
https://github.com/BHoM/Versioning_Toolkit/pull/101
https://github.com/BHoM/Rhinoceros_Toolkit/pull/176

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1016 

<!-- Add short description of what has been fixed -->




### Test files
<!-- Link to test files to validate the proposed changes -->
[Test file ](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%2FGeometry%5FoM%2DIssue1016%2DBRepVolume&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) for versioning, as well as successful conversion with volume set from Rhino

### Note
See Engine PR for modification to Translation method for BoundaryRepresentations.
Volume should be invalidated for any non-rigid body translations.

Test script shows some translations not working for some NURBS - out of scope of these PRs
But Volume should be NaN where not Null for any non-linear transformations.

