### PR TITLE
Analytical_oM: Add mesh result interface

### DIFF
--- a/Analytical_oM/Analytical_oM.csproj
+++ b/Analytical_oM/Analytical_oM.csproj
@@ -53,6 +53,8 @@
     <Compile Include="Elements\ISurface.cs" />
     <Compile Include="IAnalytical.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Results\IMeshElementResult.cs" />
+    <Compile Include="Results\IMeshResult.cs" />
     <Compile Include="Results\IResult.cs" />
     <Compile Include="Results\IResultCollection.cs" />
   </ItemGroup>

--- a/Analytical_oM/Results/IMeshElementResult.cs
+++ b/Analytical_oM/Results/IMeshElementResult.cs
@@ -32,10 +32,10 @@ namespace BH.oM.Analytical.Results
     [Description("Base interface for mesh element results. This is the result for a single discrete node or face of the mesh the result aligns with.")]
     public interface IMeshElementResult : IResult
     {
-        [Description("Id of the Node in the mesh that this result belongs to.")]
+        [Description("ID of the Node in the mesh that this result belongs to.")]
         IComparable NodeId { get; }
 
-        [Description("Id of the MeshFace that this result belongs to.")]
+        [Description("ID of the MeshFace that this result belongs to.")]
         IComparable MeshFaceId { get; }
     }
 }

--- a/Analytical_oM/Results/IMeshElementResult.cs
+++ b/Analytical_oM/Results/IMeshElementResult.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+
+namespace BH.oM.Analytical.Results
+{
+    [Description("Base interface for mesh element results. This is the result for a single discrete node of face of the mesh the result aligns with.")]
+    public interface IMeshElementResult : IResult
+    {
+        [Description("Id of the Node in the mesh that this result belongs to.")]
+        IComparable NodeId { get; }
+
+        [Description("Id of the MeshFace that this result belongs to.")]
+        IComparable MeshFaceId { get; }
+    }
+}

--- a/Analytical_oM/Results/IMeshElementResult.cs
+++ b/Analytical_oM/Results/IMeshElementResult.cs
@@ -29,7 +29,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Analytical.Results
 {
-    [Description("Base interface for mesh element results. This is the result for a single discrete node of face of the mesh the result aligns with.")]
+    [Description("Base interface for mesh element results. This is the result for a single discrete node or face of the mesh the result aligns with.")]
     public interface IMeshElementResult : IResult
     {
         [Description("Id of the Node in the mesh that this result belongs to.")]

--- a/Analytical_oM/Results/IMeshResult.cs
+++ b/Analytical_oM/Results/IMeshResult.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+
+namespace BH.oM.Analytical.Results
+{
+    [Description("Base interface for any Mesh result class which is a collection of discrete MeshElementResults.")]
+    public interface IMeshResult<T> : IResultCollection<T> where T : IMeshElementResult
+    {
+
+    }
+}

--- a/Structure_oM/Results/Mesh/MeshElementResult.cs
+++ b/Structure_oM/Results/Mesh/MeshElementResult.cs
@@ -29,7 +29,7 @@ using System;
 namespace BH.oM.Structure.Results
 {
     [Description("Base class for all discrete mesh element results, that is a result for an individual node and/or face. Stores all identifier information and how to sort the results in a collection.")]
-    public abstract class MeshElementResult : IStructuralResult, IImmutable
+    public abstract class MeshElementResult : IMeshElementResult, IStructuralResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Structure_oM/Results/Mesh/MeshResult.cs
+++ b/Structure_oM/Results/Mesh/MeshResult.cs
@@ -32,7 +32,7 @@ using System.Linq;
 namespace BH.oM.Structure.Results
 {
     [Description("Full collection of discrete results for a Panel/FEMesh for a specific Loadcase or LoadCombination.")]
-    public class MeshResult : IResult, IResultCollection<MeshElementResult>, IStructuralResult, IImmutable
+    public class MeshResult : IResult, IMeshResult<MeshElementResult>, IStructuralResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1019 

<!-- Add short description of what has been fixed -->

Adding IMeshResult and IMeshElement result itnerfaces to analytical_oM
Applying the interface to the structural results.

First step in aligning result display and management for Mesh results

### Test files
<!-- Link to test files to validate the proposed changes -->

Pulling structural results should still work with 0 difference:

https://burohappold.sharepoint.com/:f:/s/BHoM/EquJuQS0tyRNgF7YNuL5qBwBzdLgb4se7tbFNyLAODH7pQ?e=FYCxK9

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->