### PR TITLE
Facade_oM: Creation of Initial Facade_oM

### DIFF
--- a/BHoM.sln
+++ b/BHoM.sln
@@ -53,6 +53,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Spatial_oM", "Spatial_oM\Sp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Inspection_oM", "Inspection_oM\Inspection_oM.csproj", "{E86110C7-43BD-40BA-B6D6-CD144C4F1E22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Facade_oM", "Facade_oM\Facade_oM.csproj", "{D92CAFAC-D419-42BA-A9DC-4B7DAD976A8F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -147,6 +149,10 @@ Global
 		{E86110C7-43BD-40BA-B6D6-CD144C4F1E22}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E86110C7-43BD-40BA-B6D6-CD144C4F1E22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E86110C7-43BD-40BA-B6D6-CD144C4F1E22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D92CAFAC-D419-42BA-A9DC-4B7DAD976A8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D92CAFAC-D419-42BA-A9DC-4B7DAD976A8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D92CAFAC-D419-42BA-A9DC-4B7DAD976A8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D92CAFAC-D419-42BA-A9DC-4B7DAD976A8F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Facade_oM/Elements/CurtainWall.cs
+++ b/Facade_oM/Elements/CurtainWall.cs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+using BH.oM.Dimensional;
+using BH.oM.Geometry;
+
+using BH.oM.Analytical.Elements;
+using BH.oM.Physical.Constructions;
+using System.ComponentModel;
+
+namespace BH.oM.Facade.Elements
+{
+    [Description("A facade object used to define a curtain wall made up of multiple openings.")]
+    public class CurtainWall : BHoMObject, IFacadeObject, IPanel<FrameEdge, Opening>, IElement2D, IElementM
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("A collection of FrameEdge objects which defines the external boundary of the CurtainWall")]
+        public virtual List<FrameEdge> ExternalEdges { get; set; } = new List<FrameEdge>();
+
+        [Description("A collection of all openings that make up the curtain wall")]
+        public virtual List<Opening> Openings { get; set; } = new List<Opening>();
+
+
+        /***************************************************/
+    }
+}
+

--- a/Facade_oM/Elements/Enums/FrameCornerType.cs
+++ b/Facade_oM/Elements/Enums/FrameCornerType.cs
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+ using System.ComponentModel;
+
+namespace BH.oM.Facade.Elements
+{
+    [Description("The type of join at frame corners")]
+    public enum FrameCornerType
+    {
+        Undefined,
+        HorizontalExtended,
+        Mitred,
+        VerticalExtended
+    }
+}
+

--- a/Facade_oM/Elements/Enums/FrameEdgeType.cs
+++ b/Facade_oM/Elements/Enums/FrameEdgeType.cs
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+ using System.ComponentModel;
+
+namespace BH.oM.Facade.Elements
+{
+    [Description("The different edge types that make up an opening's frame")]
+    public enum FrameEdgeType
+    {
+        Undefined,
+        Head,
+        Left,
+        Right,
+        Sill,
+    }
+}
+

--- a/Facade_oM/Elements/Enums/OpeningType.cs
+++ b/Facade_oM/Elements/Enums/OpeningType.cs
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+ using System.ComponentModel;
+
+namespace BH.oM.Facade.Elements
+{
+    [Description("The type of cutout or hole in a building surface/panel (e.g. Window, Door, Rooflight)")]
+    public enum OpeningType
+    {
+        Undefined,
+        CurtainWall,
+        Door,
+        Frame,
+        Glazing,
+        Hole,
+        Rooflight,
+        RooflightWithFrame,
+        Window,
+        WindowWithFrame,
+        VehicleDoor,
+    }
+}
+

--- a/Facade_oM/Elements/Enums/PanelType.cs
+++ b/Facade_oM/Elements/Enums/PanelType.cs
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+namespace BH.oM.Facade.Elements
+{
+    [Description("The type of surface (e.g. AirGap, Internal Wall, External Wall, etc.)")]
+    public enum PanelType
+    {
+        Undefined,
+        AirGap,
+        Shade,
+        Spandrel,
+        WallExternal
+    }
+}
+

--- a/Facade_oM/Elements/FrameEdge.cs
+++ b/Facade_oM/Elements/FrameEdge.cs
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using BH.oM.Dimensional;
+using BH.oM.Geometry;
+using BH.oM.Base;
+using BH.oM.Analytical.Elements;
+using BH.oM.Physical.Constructions;
+using System.ComponentModel;
+using BH.oM.Facade.SectionProperties;
+
+namespace BH.oM.Facade.Elements
+{
+    [Description("A frame edge (eg mullion, window jamb, curtain wall sill, etc)")]
+    public class FrameEdge : BHoMObject, IEdge
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("The curve representing the frame edge location")]
+        public virtual ICurve Curve { get; set; } = null;
+
+        [Description("The property assigned to this frame edge")]
+        public virtual FrameEdgeProperty FrameEdgeProperty { get; set; } = null;
+
+        /***************************************************/
+    }
+}
+

--- a/Facade_oM/Elements/Opening.cs
+++ b/Facade_oM/Elements/Opening.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using BH.oM.Dimensional;
+using BH.oM.Geometry;
+using BH.oM.Base;
+using BH.oM.Analytical.Elements;
+using BH.oM.Physical.Constructions;
+using System.ComponentModel;
+using BH.oM.Facade.SectionProperties;
+
+namespace BH.oM.Facade.Elements
+{
+    [Description("A cutout or hole in a building surface/panel (e.g. Window, Rooflight)")]
+    public class Opening : BHoMObject, IFacadeObject, IOpening<FrameEdge>, IElement2D, IElementM
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("A collection of FrameEdges which define the external boundary of the opening.")]
+        public virtual List<FrameEdge> Edges { get; set; } = new List<FrameEdge>();
+
+        [Description("A construction object providing construction information about the opening - typically glazing construction")]
+        public virtual IConstruction OpeningConstruction { get; set; } = null;
+
+        [Description("Frame edge treatment at corners (ie Mitred, Vertical Extends, or Horizontal Extends)")]
+        public virtual FrameCornerType FrameCornerType { get; set; } = FrameCornerType.VerticalExtended;
+
+        [Description("The type of opening on a panel (e.g. Window, Door). Use OpeningType enum")]
+        public virtual OpeningType Type { get; set; } = OpeningType.Undefined;
+
+        /***************************************************/
+    }
+}
+

--- a/Facade_oM/Elements/Panel.cs
+++ b/Facade_oM/Elements/Panel.cs
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+using BH.oM.Dimensional;
+using BH.oM.Geometry;
+
+using BH.oM.Analytical.Elements;
+using BH.oM.Physical.Constructions;
+using System.ComponentModel;
+
+namespace BH.oM.Facade.Elements
+{
+    [Description("A facade object used to define planar surfaces such as walls")]
+    public class Panel : BHoMObject, IFacadeObject, IPanel<FrameEdge, Opening>, IElement2D, IElementM
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("A collection of Edge objects which defines the external boundary of the panel")]
+        public virtual List<FrameEdge> ExternalEdges { get; set; } = new List<FrameEdge>();
+
+        [Description("A collection of cutouts or holes in a building surface/panel (e.g. Window, Door, Rooflight)")]
+        public virtual List<Opening> Openings { get; set; } = new List<Opening>();
+
+        [Description("A construction object providing layer and material information for the panel")]
+        public virtual IConstruction Construction { get; set; } = null;
+
+        [Description("The type of surface (e.g. Exterior wall, interior wall, air gap). Use PanelType enum")]
+        public virtual PanelType Type { get; set; } = PanelType.Undefined;
+
+        /***************************************************/
+    }
+}
+

--- a/Facade_oM/Facade_oM.csproj
+++ b/Facade_oM/Facade_oM.csproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D92CAFAC-D419-42BA-A9DC-4B7DAD976A8F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.oM.Facade_oM</RootNamespace>
+    <AssemblyName>Facade_oM</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Analytical_oM\Analytical_oM.csproj">
+      <Project>{c91f1981-1148-4a03-b67e-c0bb42d862f4}</Project>
+      <Name>Analytical_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\BHoM\BHoM.csproj">
+      <Project>{94d88927-62a2-48fc-8efe-d139b67a3373}</Project>
+      <Name>BHoM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Dimensional_oM\Dimensional_oM.csproj">
+      <Project>{17141a37-4853-4558-af36-134a580bf42b}</Project>
+      <Name>Dimensional_oM</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Geometry_oM\Geometry_oM.csproj">
+      <Project>{5B09A2E5-CBF5-43E2-8D98-B5035391DB7B}</Project>
+      <Name>Geometry_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Physical_oM\Physical_oM.csproj">
+      <Project>{fb790ab1-5914-4797-886f-c4cb469ec168}</Project>
+      <Name>Physical_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Quantities_oM\Quantities_oM.csproj">
+      <Project>{2a5d5a00-d404-4f7e-b771-2fc837145361}</Project>
+      <Name>Quantities_oM</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Reflection_oM\Reflection_oM.csproj">
+      <Project>{29e6dcd7-270a-45cc-ac0b-6c024287645e}</Project>
+      <Name>Reflection_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Elements\Enums\FrameCornerType.cs" />
+    <Compile Include="Elements\FrameEdge.cs" />
+    <Compile Include="Elements\Enums\OpeningType.cs" />
+    <Compile Include="Elements\Enums\PanelType.cs" />
+    <Compile Include="Elements\CurtainWall.cs" />
+    <Compile Include="Elements\Opening.cs" />
+    <Compile Include="Elements\Panel.cs" />
+    <Compile Include="IFacadeObject.cs" />
+    <Compile Include="IProperty.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SectionProperties\FrameEdgeProperty.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y
+    </PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/Facade_oM/IFacadeObject.cs
+++ b/Facade_oM/IFacadeObject.cs
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+
+namespace BH.oM.Facade
+{
+    public interface IFacadeObject : IBHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+
+        /***************************************************/
+    }
+}
+

--- a/Facade_oM/IProperty.cs
+++ b/Facade_oM/IProperty.cs
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+namespace BH.oM.Facade
+{
+    [Description("Base interface for all facade properties.")]
+    public interface IProperty
+    {
+    }
+}

--- a/Facade_oM/Properties/AssemblyInfo.cs
+++ b/Facade_oM/Properties/AssemblyInfo.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Facade_oM")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Facade_oM")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bfb61138-8861-4422-b157-5ca4177dec6e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]
+

--- a/Facade_oM/SectionProperties/FrameEdgeProperty.cs
+++ b/Facade_oM/SectionProperties/FrameEdgeProperty.cs
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using System.Collections.Generic;
+using BH.oM.Base;
+using BH.oM.Physical.FramingProperties;
+
+namespace BH.oM.Facade.SectionProperties
+{
+    [Description("Frame edge (eg mullion, window jamb, curtain wall sill, etc) property with list of Profile Section properties that make up the mullion construction.")]
+    public class FrameEdgeProperty : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Collection of profiles that make up the mullion, each containing section geometry and a material.")]
+        public virtual List<ConstantFramingProperty> SectionProperties { get; set; } = null;
+
+        /***************************************************/
+    }
+}
+


### PR DESCRIPTION
### Issues addressed by this PR
Closes #975 

Adding initial facade om objects. These objects include critical objects for curtain walls and openings and the frame properties required to describe them to a facades-required level of detail.