### PR TITLE
Structure_oM: Fixing default values of some properties

### DIFF
--- a/Structure_oM/Elements/FEMesh.cs
+++ b/Structure_oM/Elements/FEMesh.cs
@@ -41,7 +41,7 @@ namespace BH.oM.Structure.Elements
         public virtual List<FEMeshFace> Faces { get; set; } = new List<FEMeshFace>();
 
         [Description("Defines the thickness property and material of the FEMesh.")]
-        public virtual ISurfaceProperty Property { get; set; } = new ConstantThickness();
+        public virtual ISurfaceProperty Property { get; set; } = null;
 
         /***************************************************/
     }

--- a/Structure_oM/Elements/Panel.cs
+++ b/Structure_oM/Elements/Panel.cs
@@ -45,7 +45,7 @@ namespace BH.oM.Structure.Elements
         public virtual List<Opening> Openings { get; set; } = new List<Opening>();
 
         [Description("Defines the thickness property and material of the Panel. Orientation of non-isotropic properties are controlled by the OrientationAngle.")]
-        public virtual ISurfaceProperty Property { get; set; } = new ConstantThickness();
+        public virtual ISurfaceProperty Property { get; set; } = null;
 
         [Angle]
         [Description("Defines the angle that the local x and y axes are rotated around the normal (i.e. local z) of the Panel.\n" +

--- a/Structure_oM/SectionProperties/ConcreteSection.cs
+++ b/Structure_oM/SectionProperties/ConcreteSection.cs
@@ -43,7 +43,7 @@ namespace BH.oM.Structure.SectionProperties
         public override string Name { get; set; }
 
         [Description("List of Reinforcement of the concrete section.")]
-        public virtual List<Reinforcement.IBarReinforcement> Reinforcement { get; set; }
+        public virtual List<Reinforcement.IBarReinforcement> Reinforcement { get; set; } = new List<Reinforcement.IBarReinforcement>();
 
         [Length]
         [Description("Minimum reinforcement cover of the section.")]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #644

<!-- Add short description of what has been fixed -->

Removes non-sensical default values of an empty constant thickness property for Panel and FEMesh.
Adding in default empty list for bar reinforcement on the concrete section.


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->