### PR TITLE
Reflection_oM: Path attribute classes made non-abstract

### DIFF
--- a/Reflection_oM/Attributes/FilePathAttribute.cs
+++ b/Reflection_oM/Attributes/FilePathAttribute.cs
@@ -28,7 +28,7 @@ using System.ComponentModel;
 namespace BH.oM.Reflection.Attributes
 {
     [Description("Path to a folder in the client's file system.")]
-    public abstract class FilePathAttribute : InputClassificationAttribute
+    public class FilePathAttribute : InputClassificationAttribute
     {
     }
 }

--- a/Reflection_oM/Attributes/FolderPathAttribute.cs
+++ b/Reflection_oM/Attributes/FolderPathAttribute.cs
@@ -28,7 +28,7 @@ using System.ComponentModel;
 namespace BH.oM.Reflection.Attributes
 {
     [Description("Path to a folder in the client's file system.")]
-    public abstract class FolderPathAttribute : InputClassificationAttribute
+    public class FolderPathAttribute : InputClassificationAttribute
     {
     }
 }


### PR DESCRIPTION
Closes #1081

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed, cosmetic change.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- path attribute classes made non-abstract


### Additional comments
<!-- As required -->