### PR TITLE
Security_oM: Added Security oM with initial CameraDevice definition

### DIFF
--- a/BHoM.sln
+++ b/BHoM.sln
@@ -57,6 +57,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Facade_oM", "Facade_oM\Faca
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test_oM", "Test_oM\Test_oM.csproj", "{360F27AF-6A77-4718-8B44-A4B62F0E44FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Security_oM", "Security_oM\Security_oM.csproj", "{0B4A43AD-DF52-49C2-B507-8B4D971B235C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +161,10 @@ Global
 		{360F27AF-6A77-4718-8B44-A4B62F0E44FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{360F27AF-6A77-4718-8B44-A4B62F0E44FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{360F27AF-6A77-4718-8B44-A4B62F0E44FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B4A43AD-DF52-49C2-B507-8B4D971B235C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B4A43AD-DF52-49C2-B507-8B4D971B235C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B4A43AD-DF52-49C2-B507-8B4D971B235C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B4A43AD-DF52-49C2-B507-8B4D971B235C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Security_oM/Elements/CameraDevice.cs
+++ b/Security_oM/Elements/CameraDevice.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Base;
+using BH.oM.Security.Enums;
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.oM.Security.Elements
+{
+    [Description("A camera object is a electronic security device typically used in closed-circuit television (CCTV) systems.")]
+    public class CameraDevice : BHoMObject, IElement0D, IElement1D, IElementM
+    {
+        /***************************************************/
+        /****                Properties                 ****/
+        /***************************************************/
+
+        [Description("The point at which the Camera is installed, known as the eye position.")]
+        public virtual Point EyePosition { get; set; } = new Point();
+
+        [Description("The point at which the Camera is looking at, known as the target position.")]
+        public virtual Point TargetPosition { get; set; } = new Point();
+        
+        [Length]
+        [Description("The horizontal field of view of the Camera, known as the real-world width length of what the camera views.")]
+        public virtual double HorizontalFieldOfView { get; set; } = 0;               
+
+        [Description("The Camera mounting type that describes how it's installed.")]
+        public virtual MountingType Mounting { get; set; } = MountingType.Undefined;
+
+        [Description("The Camera type that describes its characteristics.")]
+        public virtual CameraType Type { get; set; } = CameraType.Undefined;        
+
+        [Description("The Camera megapixels that determines its image quality.")]
+        public virtual double Megapixels { get; set; } = 0;
+
+        [Description("A means of adding an electrical connector part to the camera's properties. Gives the ability to add the voltage, amps, and denotes if the fixture should be on emergency power.")]
+        public virtual List<IBHoMObject> Parts { get; set; } = new List<IBHoMObject>();
+
+        /***************************************************/
+    }
+}

--- a/Security_oM/Elements/CameraDevice.cs
+++ b/Security_oM/Elements/CameraDevice.cs
@@ -31,7 +31,7 @@ using BH.oM.Quantities.Attributes;
 namespace BH.oM.Security.Elements
 {
     [Description("A camera object is a electronic security device typically used in closed-circuit television (CCTV) systems.")]
-    public class CameraDevice : BHoMObject, IElement0D, IElement1D, IElementM
+    public class CameraDevice : BHoMObject, IElement0D, IElementM
     {
         /***************************************************/
         /****                Properties                 ****/
@@ -55,9 +55,6 @@ namespace BH.oM.Security.Elements
 
         [Description("The Camera megapixels that determines its image quality.")]
         public virtual double Megapixels { get; set; } = 0;
-
-        [Description("A means of adding an electrical connector part to the camera's properties. Gives the ability to add the voltage, amps, and denotes if the fixture should be on emergency power.")]
-        public virtual List<IBHoMObject> Parts { get; set; } = new List<IBHoMObject>();
 
         /***************************************************/
     }

--- a/Security_oM/Enums/CameraType.cs
+++ b/Security_oM/Enums/CameraType.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+namespace BH.oM.Security.Enums
+{
+    /***************************************************/
+
+    [Description("A camera type that describes its basic characteristcs.")]
+    public enum CameraType
+    {
+        Undefined,
+        Bullet,        
+        Covert,
+        Domed,
+        Fisheye,
+        MultiMegapixels,
+        PanTiltZoom        
+    }
+
+    /***************************************************/
+}

--- a/Security_oM/Enums/MountingType.cs
+++ b/Security_oM/Enums/MountingType.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+
+namespace BH.oM.Security.Enums
+{
+    /***************************************************/
+
+    [Description("A mounting type that describes how a fitting is installed.")]
+    public enum MountingType
+    {
+        Undefined,
+        Ceiling,
+        Column,
+        Facade,
+        Floor,
+        Pendant,
+        Soffit,
+        Wall   
+    }
+
+    /***************************************************/
+}

--- a/Security_oM/Properties/AssemblyInfo.cs
+++ b/Security_oM/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Security_oM")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Security_oM")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0b4a43ad-df52-49c2-b507-8b4d971b235c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/Security_oM/Security_oM.csproj
+++ b/Security_oM/Security_oM.csproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0B4A43AD-DF52-49C2-B507-8B4D971B235C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.oM.Security</RootNamespace>
+    <AssemblyName>Security_oM</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Analytical_oM\Analytical_oM.csproj">
+      <Project>{c91f1981-1148-4a03-b67e-c0bb42d862f4}</Project>
+      <Name>Analytical_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\BHoM\BHoM.csproj">
+      <Project>{94d88927-62a2-48fc-8efe-d139b67a3373}</Project>
+      <Name>BHoM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Dimensional_oM\Dimensional_oM.csproj">
+      <Project>{17141a37-4853-4558-af36-134a580bf42b}</Project>
+      <Name>Dimensional_oM</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Geometry_oM\Geometry_oM.csproj">
+      <Project>{5B09A2E5-CBF5-43E2-8D98-B5035391DB7B}</Project>
+      <Name>Geometry_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Physical_oM\Physical_oM.csproj">
+      <Project>{fb790ab1-5914-4797-886f-c4cb469ec168}</Project>
+      <Name>Physical_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Quantities_oM\Quantities_oM.csproj">
+      <Project>{2a5d5a00-d404-4f7e-b771-2fc837145361}</Project>
+      <Name>Quantities_oM</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Reflection_oM\Reflection_oM.csproj">
+      <Project>{29e6dcd7-270a-45cc-ac0b-6c024287645e}</Project>
+      <Name>Reflection_oM</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Elements\CameraDevice.cs" />
+    <Compile Include="Enums\CameraType.cs" />
+    <Compile Include="Enums\MountingType.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y
+    </PostBuildEvent>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
   
### Issues addressed by this PR

Closes #1078 

Created Security_oM and added the definition for CameraDevice.

Added new object `BH.oM.Security.Elements.CameraDevice`
Added new enums `BH.oM.Security.Enums.CameraType`
Added new enums `BH.oM.Security.Enums.MountingType`