### PR TITLE
MEP_oM: Addition of Generic Mechanical Equipment object

### DIFF
--- a/MEP_oM/Enums/MechanicalEquipmentType.cs
+++ b/MEP_oM/Enums/MechanicalEquipmentType.cs
@@ -1,0 +1,31 @@
+﻿using System.ComponentModel;
+
+namespace BH.oM.MEP.Enums
+{
+    /***************************************************/
+
+    [Description("A type of mechanical equipment (air handling unit, boiler, chiller, fan coil unit.)")]
+    public enum MechanicalEquipmentType
+    {
+        Undefined,
+        AirHandlingUnit,
+        AirSeparator,
+        AirSourceHeatPump,
+        Boiler,
+        CabinetUnitHeater,
+        Chiller,
+        CoolingTower,
+        ExpansionTankVessel,
+        Fan,
+        FanCoilUnit,
+        HeatExchanger,
+        HeatingAndVentilationUnit,
+        Pump,
+        UnitHeater,
+        VariableAirVolumeBox,
+        WaterSourceHeatPump,
+        WaterStorageTank,
+    }
+
+    /***************************************************/
+}

--- a/MEP_oM/Enums/MechanicalEquipmentType.cs
+++ b/MEP_oM/Enums/MechanicalEquipmentType.cs
@@ -23,6 +23,8 @@ namespace BH.oM.MEP.Enums
         Pump,
         UnitHeater,
         VariableAirVolumeBox,
+        VariableRefrigerantFlowCondenserIndoor,
+        VariableRefrigerantFlowEvaporatorOutdoor,
         WaterSourceHeatPump,
         WaterStorageTank,
     }

--- a/MEP_oM/Enums/MechanicalEquipmentType.cs
+++ b/MEP_oM/Enums/MechanicalEquipmentType.cs
@@ -1,4 +1,26 @@
-﻿using System.ComponentModel;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
 
 namespace BH.oM.MEP.Enums
 {

--- a/MEP_oM/Equipment/MechanicalEquipment.cs
+++ b/MEP_oM/Equipment/MechanicalEquipment.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.MEP.Equipment.Parts;
+using BH.oM.MEP.Enums;
+using BH.oM.Geometry;
+
+namespace BH.oM.MEP.Equipment
+{
+    class MechanicalEquipment
+    {
+        [Description("A type which describes the mechanical equipment more specifically whether it's an air handling unit, fan coil unit, boiler or chiller.")]
+        public virtual MechanicalEquipmentType MechanicalEquipmentType { get; set; } = MechanicalEquipmentType.Undefined;
+
+        [Description("A collection of the parts (Air Handling Unit, Fans, Coils, Energy Wheel, Filters, Electrical Connectors) that make up the Air Handling Unit")]
+        public virtual List<IPart> Parts { get; set; } = new List<IPart>();
+
+        [Description("The point in space for the location of the mechanical equipment.")]
+        public virtual Point Position { get; set; } = new Point();
+    }
+}

--- a/MEP_oM/Equipment/MechanicalEquipment.cs
+++ b/MEP_oM/Equipment/MechanicalEquipment.cs
@@ -1,12 +1,35 @@
-﻿using System.Collections.Generic;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
 using System.ComponentModel;
 using BH.oM.MEP.Equipment.Parts;
 using BH.oM.MEP.Enums;
+using BH.oM.Base;
 using BH.oM.Geometry;
 
 namespace BH.oM.MEP.Equipment
 {
-    class MechanicalEquipment
+    public class MechanicalEquipment : BHoMObject, IEquipment
     {
         [Description("A type which describes the mechanical equipment more specifically whether it's an air handling unit, fan coil unit, boiler or chiller.")]
         public virtual MechanicalEquipmentType MechanicalEquipmentType { get; set; } = MechanicalEquipmentType.Undefined;

--- a/MEP_oM/MEP_oM.csproj
+++ b/MEP_oM/MEP_oM.csproj
@@ -40,6 +40,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Enums\MechanicalEquipmentType.cs" />
+    <Compile Include="Equipment\MechanicalEquipment.cs" />
     <Compile Include="System\ConnectionProperties\CableTrayConnectionProperty.cs" />
     <Compile Include="System\ConnectionProperties\IConnectionProperty.cs" />
     <Compile Include="System\CableTray.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1094 

Generic Mechanical Equipment Object added
MechanicalEquipmentType enum added
![image](https://user-images.githubusercontent.com/34316256/99432718-87b99480-28da-11eb-8100-a65cd62b1165.png)

Workflow Prototype (assign type enum after pull):
![image](https://user-images.githubusercontent.com/34316256/99432634-6ce72000-28da-11eb-9ca6-1dbdc3bb1dfa.png)

### Additional comments
@Hmullerjones to review the enum for the mechanical equipment types for UK understanding of my American verbiage :) 