### PR TITLE
Physical_oM: Create ExplicitBulk Element

### DIFF
--- a/Physical_oM/Elements/ExplicitBulk.cs
+++ b/Physical_oM/Elements/ExplicitBulk.cs
@@ -34,8 +34,8 @@ namespace BH.oM.Physical.Elements
         /**** Properties                                ****/
         /***************************************************/
 
-        public virtual double Volume { get; set; }
-        public virtual MaterialComposition MaterialComposition { get; set; }
+        public virtual double Volume { get; set; } = 0;
+        public virtual MaterialComposition MaterialComposition { get; set; } = null;
 
         /***************************************************/
     }

--- a/Physical_oM/Elements/ExplicitBulk.cs
+++ b/Physical_oM/Elements/ExplicitBulk.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Base;
+using BH.oM.Physical.Materials;
+using BH.oM.Dimensional;
+
+namespace BH.oM.Physical.Elements
+{
+    public class ExplicitBulk : BHoMObject, IElementM
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual double Volume { get; set; }
+        public virtual MaterialComposition MaterialComposition { get; set; }
+
+        /***************************************************/
+    }
+}
+

--- a/Physical_oM/Elements/SolidBulk.cs
+++ b/Physical_oM/Elements/SolidBulk.cs
@@ -34,8 +34,8 @@ namespace BH.oM.Physical.Elements
         /***************************************************/
 
         [Description("A list of geometric solids defining the bulk geometry.")]
-        public virtual List<BH.oM.Geometry.ISolid> Geometry { get; set; }
-        public virtual MaterialComposition MaterialComposition { get; set; }
+        public virtual List<BH.oM.Geometry.ISolid> Geometry { get; set; } = null;
+        public virtual MaterialComposition MaterialComposition { get; set; } = null;
 
         /***************************************************/
     }

--- a/Physical_oM/Elements/SolidBulk.cs
+++ b/Physical_oM/Elements/SolidBulk.cs
@@ -27,7 +27,7 @@ using BH.oM.Physical.Materials;
 
 namespace BH.oM.Physical.Elements
 {
-    public class BulkSolids : BHoMObject, ISolid
+    public class SolidBulk : BHoMObject, ISolid
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Physical_oM/Elements/SolidBulk.cs
+++ b/Physical_oM/Elements/SolidBulk.cs
@@ -34,7 +34,7 @@ namespace BH.oM.Physical.Elements
         /***************************************************/
 
         [Description("A list of geometric solids defining the bulk geometry.")]
-        public virtual List<BH.oM.Geometry.ISolid> Geometry { get; set; } = null;
+        public virtual List<BH.oM.Geometry.ISolid> Geometry { get; set; } = new List<Geometry.ISolid>();
         public virtual MaterialComposition MaterialComposition { get; set; } = null;
 
         /***************************************************/

--- a/Physical_oM/Physical_oM.csproj
+++ b/Physical_oM/Physical_oM.csproj
@@ -54,8 +54,9 @@
     <Compile Include="Elements\Door.cs" />
     <Compile Include="Elements\Beam.cs" />
     <Compile Include="Constructions\Layer.cs" />
+    <Compile Include="Elements\ExplicitBulk.cs" />
     <Compile Include="FramingProperties\ConstantFramingProperty.cs" />
-    <Compile Include="Elements\BulkSolids.cs" />
+    <Compile Include="Elements\SolidBulk.cs" />
     <Compile Include="Materials\MaterialComposition.cs" />
     <Compile Include="Materials\Material.cs" />
     <Compile Include="Elements\Wall.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1088 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/Physical_oM/Physical_oM-Issue1088-ExplicitBulk/ExplicitBulk.gh?csf=1&web=1&e=LwundV)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Should also note that this PR changes the name of the newly created `BulkSolids` to `SolidBulk`. No versioning required since this object has likely not found its way into any workflows since its very recent creation within the 4.0 milestone. All extension methods have also been adjusted in the linked Physical_Engine PR. 

### Additional comments
<!-- As required -->