### PR TITLE
BHoM: IAdapterId and IPersistentId interfaces to require only get

### DIFF
--- a/BHoM/Interface/IAdapterId.cs
+++ b/BHoM/Interface/IAdapterId.cs
@@ -29,7 +29,7 @@ namespace BH.oM.Base
     public interface IAdapterId : IFragment
     {
         [Description("Identifier of the object in the external software.")]
-        object Id { get; set; }
+        object Id { get; }
     }
 }
 

--- a/BHoM/Interface/IPersistentAdapterId.cs
+++ b/BHoM/Interface/IPersistentAdapterId.cs
@@ -29,7 +29,7 @@ namespace BH.oM.Base
     public interface IPersistentAdapterId : IFragment
     {
         [Description("Globally unique and generated upon object creation in the external software; it never changes throughout the life of the object.")]
-        object PersistentId { get; set; }
+        object PersistentId { get; }
     }
 }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1115 

<!-- Add short description of what has been fixed -->
This is to allow for Identifier objects that implement also `IImmutable`. 
The `set` is not a requirement from the perspective of the `IAdapterId`/`IPersistentId` interfaces.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->