### PR TITLE
Facade_oM: ConstructionOffsetFragment

### DIFF
--- a/Facade_oM/Facade_oM.csproj
+++ b/Facade_oM/Facade_oM.csproj
@@ -83,7 +83,7 @@
     <Compile Include="Elements\CurtainWall.cs" />
     <Compile Include="Elements\Opening.cs" />
     <Compile Include="Elements\Panel.cs" />
-    <Compile Include="Fragments\ConstructionOffsetFragment.cs" />
+    <Compile Include="Fragments\ConstructionOffset.cs" />
     <Compile Include="IFacadeObject.cs" />
     <Compile Include="IProperty.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Facade_oM/Facade_oM.csproj
+++ b/Facade_oM/Facade_oM.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Elements\CurtainWall.cs" />
     <Compile Include="Elements\Opening.cs" />
     <Compile Include="Elements\Panel.cs" />
+    <Compile Include="Fragments\ConstructionOffsetFragment.cs" />
     <Compile Include="IFacadeObject.cs" />
     <Compile Include="IProperty.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Facade_oM/Fragments/ConstructionOffset.cs
+++ b/Facade_oM/Fragments/ConstructionOffset.cs
@@ -32,9 +32,16 @@ using System.ComponentModel;
 
 namespace BH.oM.Facade.Fragments
 {
-    [Description("Fragment containing the offset distance of a construction type from the center line")]
-    public class ConstructionOffsetFragment : IFragment
+    [Description("Fragment containing the offset distance of a construction type from the facade center line")]
+    public class ConstructionOffset : IFragment
     {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Offset distance from centerline of wall type or glazing section from centerline of facade section")]
         public virtual double OffsetDistance { get; set; } = 0;
+
+        /***************************************************/
     }
 }

--- a/Facade_oM/Fragments/ConstructionOffset.cs
+++ b/Facade_oM/Fragments/ConstructionOffset.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -39,7 +39,7 @@ namespace BH.oM.Facade.Fragments
         /**** Properties                                ****/
         /***************************************************/
 
-        [Description("Offset distance from centerline of wall type or glazing section from centerline of facade section")]
+        [Description("Offset distance from centerline of wall or glazing section from centerline of facade section")]
         public virtual double OffsetDistance { get; set; } = 0;
 
         /***************************************************/

--- a/Facade_oM/Fragments/ConstructionOffsetFragment.cs
+++ b/Facade_oM/Fragments/ConstructionOffsetFragment.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+
+using System.ComponentModel;
+
+namespace BH.oM.Facade.Fragments
+{
+    [Description("Fragment containing the offset distance of a construction type from the center line")]
+    public class ConstructionOffsetFragment : IFragment
+    {
+        public virtual double OffsetDistance { get; set; } = 0;
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1140 

Adding fragment to Facade_oM that defines offset distance. This can be applied to wall cross sections or glazing cross sections to offset them from the facade centerline.