### PR TITLE
Lighting_oM: Make constructor public instead of protected

### DIFF
--- a/Lighting_oM/Results/Illuminance/Lux.cs
+++ b/Lighting_oM/Results/Illuminance/Lux.cs
@@ -47,7 +47,7 @@ namespace BH.oM.Lighting.Results.Illuminance
         /**** Constructors                              ****/
         /***************************************************/
 
-        protected Lux(IComparable objectId, IComparable nodeId, IComparable resultCase, double timeStep, double luxLevel) : base(objectId, nodeId, resultCase, timeStep)
+        public Lux(IComparable objectId, IComparable nodeId, IComparable resultCase, double timeStep, double luxLevel) : base(objectId, nodeId, resultCase, timeStep)
         {
             LuxLevel = luxLevel;
         }


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1170

As per issue. Pretty straightforward correction of a constructor that was marked as `protected`

