### PR TITLE
Test_oM: Adding EventMessage

### DIFF
--- a/Test_oM/Results/EventMessage.cs
+++ b/Test_oM/Results/EventMessage.cs
@@ -34,12 +34,15 @@ namespace BH.oM.Test.Results
     public class EventMessage : ITestInformation
     {
         [Description("Message raised during the execution.")]
-        public virtual string Message { get; set; }
+        public virtual string Message { get; set; } = "";
 
         [Description("Severity of the message.")]
-        public virtual TestStatus Status { get; set; }
+        public virtual TestStatus Status { get; set; } = TestStatus.Error;
 
         [Description("Provides the UTC time of when the event was raised.")]
         public virtual DateTime UTCTime { get; set; } = DateTime.UtcNow;
+
+        [Description("Original location where the event was generated.")]
+        public virtual string StackTrace { get; set; } = "";
     }
 }

--- a/Test_oM/Results/EventMessage.cs
+++ b/Test_oM/Results/EventMessage.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Test;
+using System.ComponentModel;
+
+namespace BH.oM.Test.Results
+{
+    [Description("Class to store an event raised during the execution on a TestResult.")]
+    public class EventMessage : ITestInformation
+    {
+        [Description("Message raised during the execution.")]
+        public virtual string Message { get; set; }
+
+        [Description("Severity of the message.")]
+        public virtual TestStatus Status { get; set; }
+
+        [Description("Provides the UTC time of when the event was raised.")]
+        public virtual DateTime UTCTime { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Test_oM/Test_oM.csproj
+++ b/Test_oM/Test_oM.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Results\EventMessage.cs" />
     <Compile Include="TestStatus.cs" />
     <Compile Include="ITestInformation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1181 

<!-- Add short description of what has been fixed -->

Adds `EventMessage` class meant to be a place to store information from a Debug.Event as `Information` on the `TestResult`.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->