### PR TITLE
Structure_oM: Change default value of Node orientation to null

### DIFF
--- a/Structure_oM/Elements/Node.cs
+++ b/Structure_oM/Elements/Node.cs
@@ -39,8 +39,8 @@ namespace BH.oM.Structure.Elements
         [Description("Position of the node in global Cartesian 3D space.")]
         public virtual Point Position { get; set; } = null;
 
-        [Description("Local x, y, and z axes of the node as a vector Basis. Defaults to world axes.")]
-        public virtual Basis Orientation { get; set; } = Basis.XY;
+        [Description("Local x, y, and z axes of the node as a vector Basis. Defaults to null which is interpretated to defaults when pushed to software and world axes in BHoM.")]
+        public virtual Basis Orientation { get; set; } = null;
 
         [Description("Defines the Support property of the Node. If not set, the Node will be assumed to be free to translate and rotate.")]
         public virtual Constraint6DOF Support { get; set; } = null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1183 

<!-- Add short description of what has been fixed -->

Changing default value for the orientation of Nodes from world XYZ to null. A null value should be interpreted as default for the environment you are in, generally world XY.

Making this change to differentiate between explicitly set orientations and default orientations.

Important to make https://github.com/BHoM/BHoM_Adapter/pull/286 work as intended.

@peterjamesnugent @JosefTaylor will this impact any of the work you have done on the adapters?

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->