### PR TITLE
Graphics_oM: Add basic graphical objects

### DIFF
--- a/Graphics_oM/Graphics_oM.csproj
+++ b/Graphics_oM/Graphics_oM.csproj
@@ -55,6 +55,9 @@
     <Compile Include="Fragments\IRepresentationFragment.cs" />
     <Compile Include="Fragments\RelationRepresentation.cs" />
     <Compile Include="Misc\Padding.cs" />
+    <Compile Include="Render\IRender.cs" />
+    <Compile Include="Render\RenderGeometry.cs" />
+    <Compile Include="Render\RenderText.cs" />
     <Compile Include="Render\RepresentationOptions.cs" />
     <Compile Include="Render\RenderMeshOptions.cs" />
     <Compile Include="Render\RenderMesh.cs" />

--- a/Graphics_oM/Render/IRender.cs
+++ b/Graphics_oM/Render/IRender.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Graphics
+{
+
+    [Description("Base interface for rendered objects.")]
+
+    public interface IRender : IObject
+    {
+    }
+}

--- a/Graphics_oM/Render/IRender.cs
+++ b/Graphics_oM/Render/IRender.cs
@@ -31,13 +31,9 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Graphics
 {
-
     [Description("Base interface for rendered objects.")]
-
     public interface IRender : IObject
     {
-
         Color Colour { get; set; }
-
     }
 }

--- a/Graphics_oM/Render/IRender.cs
+++ b/Graphics_oM/Render/IRender.cs
@@ -24,6 +24,7 @@ using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -35,5 +36,8 @@ namespace BH.oM.Graphics
 
     public interface IRender : IObject
     {
+
+        Color Colour { get; set; }
+
     }
 }

--- a/Graphics_oM/Render/RenderGeometry.cs
+++ b/Graphics_oM/Render/RenderGeometry.cs
@@ -39,7 +39,7 @@ namespace BH.oM.Graphics
         [Description("A geometry (or many geometry objects collected into a single `CompositeGeometry` object).")]
         public virtual IGeometry Geometry { get; set; }
 
-        [Description("Colour used to render the Geometry. Default is Color.FromArgb(80, 255, 41, 105) BHoM pink.")]
+        [Description("Colour used to render the Geometry. Default is BHoM pink (Color.FromArgb(80, 255, 41, 105)).")]
         public virtual Color Colour { get; set; } = Color.FromArgb(80, 255, 41, 105);
 
         /***************************************************/

--- a/Graphics_oM/Render/RenderGeometry.cs
+++ b/Graphics_oM/Render/RenderGeometry.cs
@@ -39,7 +39,7 @@ namespace BH.oM.Graphics
         [Description("A geometry (or many geometry objects collected into a single `CompositeGeometry` object).")]
         public virtual IGeometry Geometry { get; set; }
 
-        [Description("Colour used to render the Geometry. Default is BHoM pink (Color.FromArgb(80, 255, 41, 105)).")]
+        [Description("Colour used to render the Geometry. Default is BHoM Coral with a subtle transparency (Color.FromArgb(80, 255, 41, 105)).")]
         public virtual Color Colour { get; set; } = Color.FromArgb(80, 255, 41, 105);
 
         /***************************************************/

--- a/Graphics_oM/Render/RenderGeometry.cs
+++ b/Graphics_oM/Render/RenderGeometry.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Geometry;
+
+namespace BH.oM.Graphics
+{
+    [Description("Render geometry with a specific colour.")]
+    public class RenderGeometry : IRender
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("A geometry (or many geometry objects collected into a single `CompositeGeometry` object).")]
+        public virtual IGeometry Geometry { get; set; }
+
+        [Description("Colour used to render the Geometry. Default is Color.FromArgb(80, 255, 41, 105) BHoM pink.")]
+        public virtual Color Colour { get; set; } = Color.FromArgb(80, 255, 41, 105);
+
+        /***************************************************/
+
+    }
+}

--- a/Graphics_oM/Render/RenderText.cs
+++ b/Graphics_oM/Render/RenderText.cs
@@ -48,7 +48,7 @@ namespace BH.oM.Graphics
 
         public virtual Cartesian Cartesian { get; set; } = new Cartesian();
 
-        [Description("Height of the text. Default is 1.")]
+        [Description("Height of the text. Default is 1. Units will be determined by the setting of the user interface that renders the text.")]
 
         public virtual double Height { get; set; } = 1;
 

--- a/Graphics_oM/Render/RenderText.cs
+++ b/Graphics_oM/Render/RenderText.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using BH.oM.Base;
+using BH.oM.Geometry.CoordinateSystem;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Graphics
+{
+    [Description("Render text at a location and orientation in space with specified height, font and colour.")]
+    public class TextRepresentation : IRender
+    {
+
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("The text to render.")]
+        public virtual string Text { get; set; } = "";
+
+        [Description("Cartesian to locate and orientate the text.")]
+
+        public virtual Cartesian Cartesian { get; set; } = new Cartesian();
+
+        [Description("Height of the text. Default is 1.")]
+
+        public virtual double Height { get; set; } = 1;
+
+        [Description("Font used to render the text. Default is Arial.")]
+
+        public virtual string FontName { get; set; } = "Arial";
+
+        [Description("Colour used to render the text. Default is Color.FromArgb(80, 255, 41, 105) BHoM pink.")]
+
+        public virtual Color Colour { get; set; } = Color.FromArgb(80, 255, 41, 105);
+
+        /***************************************************/
+    }
+}

--- a/Graphics_oM/Render/RenderText.cs
+++ b/Graphics_oM/Render/RenderText.cs
@@ -56,7 +56,7 @@ namespace BH.oM.Graphics
 
         public virtual string FontName { get; set; } = "Arial";
 
-        [Description("Colour used to render the text. Default is BHoM pink (Color.FromArgb(80, 255, 41, 105)).")]
+        [Description("Colour used to render the text. Default is BHoM Coral with a subtle transparency (Color.FromArgb(80, 255, 41, 105)).")]
 
         public virtual Color Colour { get; set; } = Color.FromArgb(80, 255, 41, 105);
 

--- a/Graphics_oM/Render/RenderText.cs
+++ b/Graphics_oM/Render/RenderText.cs
@@ -34,7 +34,7 @@ using System.Threading.Tasks;
 namespace BH.oM.Graphics
 {
     [Description("Render text at a location and orientation in space with specified height, font and colour.")]
-    public class TextRepresentation : IRender
+    public class RenderText : IRender
     {
 
         /***************************************************/

--- a/Graphics_oM/Render/RenderText.cs
+++ b/Graphics_oM/Render/RenderText.cs
@@ -56,7 +56,7 @@ namespace BH.oM.Graphics
 
         public virtual string FontName { get; set; } = "Arial";
 
-        [Description("Colour used to render the text. Default is Color.FromArgb(80, 255, 41, 105) BHoM pink.")]
+        [Description("Colour used to render the text. Default is BHoM pink (Color.FromArgb(80, 255, 41, 105)).")]
 
         public virtual Color Colour { get; set; } = Color.FromArgb(80, 255, 41, 105);
 


### PR DESCRIPTION
### NOTE: Depends on 
To view these objects in Rhino / Grasshopper
https://github.com/BHoM/Rhinoceros_Toolkit/pull/202
https://github.com/BHoM/Grasshopper_Toolkit/pull/602
  
### Issues addressed by this PR
Adds `RenderGeometry` and `RenderText` objects.

Closes #1190
<!-- Add short description of what has been fixed -->
[Examples of usage](https://github.com/BHoM/BHoM_Engine/pull/2288#issuecomment-776147787)

### Test files
<!-- Link to test files to validate the proposed changes -->
Set of tests [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Graphics_oM/%231191_Add_basic_graphical_objects?csf=1&web=1&e=f9Vp5s)
Run through in numbered order.

Noting that currently default bake behaviour for Render objects ALWAYS results in baking geometry or text with specified colour.
Destination layer is set by user either as current layer when baking via ctrl+space+bake
or set in attributes dialog when baking via right click on component. 
Would be good to confirm this UX with reviewers.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->