### PR TITLE
Humans_oM: Add versioning for changes to CvalueAnalysis

### DIFF
--- a/Humans_oM/Humans_oM.csproj
+++ b/Humans_oM/Humans_oM.csproj
@@ -104,6 +104,9 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Versioning_41.json" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/Humans_oM/Versioning_41.json
+++ b/Humans_oM/Versioning_41.json
@@ -1,0 +1,25 @@
+{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+
+    }
+  },
+  "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Property": {
+    "ToNew": {
+      "BH.oM.Humans.ViewQuality.CvalueSettings.RowTolerance": "BH.oM.Humans.ViewQuality.CvalueSettings.FarClippingPlaneDistance"
+    },
+    "ToOld": {
+      "BH.oM.Humans.ViewQuality.CvalueSettings.FarClippingPlaneDistance": "BH.oM.Structure.Elements.RigidLink.MasterNode.RowTolerance"
+    }
+  }
+}

--- a/Humans_oM/Versioning_41.json
+++ b/Humans_oM/Versioning_41.json
@@ -19,7 +19,7 @@
       "BH.oM.Humans.ViewQuality.CvalueSettings.RowTolerance": "BH.oM.Humans.ViewQuality.CvalueSettings.FarClippingPlaneDistance"
     },
     "ToOld": {
-      "BH.oM.Humans.ViewQuality.CvalueSettings.FarClippingPlaneDistance": "BH.oM.Structure.Elements.RigidLink.MasterNode.RowTolerance"
+      "BH.oM.Humans.ViewQuality.CvalueSettings.FarClippingPlaneDistance": "BH.oM.Humans.ViewQuality.CvalueSettings.RowTolerance"
     }
   }
 }


### PR DESCRIPTION
### NOTE: Depends on 

### Issues addressed by this PR
Property name change versioned for CValueSettings
Previous version attribute for the CValueAnalysis method

Closes #1221 
Closes #https://github.com/BHoM/BHoM_Engine/issues

<!-- Add short description of what has been fixed -->


### Test files
Old components and old json strings in this [file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Humans_oM/%231221-CvalueVersioning/%231221_cvalueversioning.gh?csf=1&web=1&e=D0d4O0)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->