### PR TITLE
Versioning_oM: Add oM from Versioning_Toolkit with VersioningEvent

### DIFF
--- a/BHoM.sln
+++ b/BHoM.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30503.244
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1500
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BHoM", "BHoM\BHoM.csproj", "{94D88927-62A2-48FC-8EFE-D139B67A3373}"
 EndProject
@@ -60,6 +60,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Security_oM", "Security_oM\Security_oM.csproj", "{0B4A43AD-DF52-49C2-B507-8B4D971B235C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lighting_oM", "Lighting_oM\Lighting_oM.csproj", "{1698931E-0BF1-4E41-BF09-EDD84AFF44D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Versioning_oM", "Versioning_oM\Versioning_oM.csproj", "{3B4BCCBC-DBB9-4DB6-A5F1-C59359892D9F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -171,6 +173,10 @@ Global
 		{1698931E-0BF1-4E41-BF09-EDD84AFF44D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1698931E-0BF1-4E41-BF09-EDD84AFF44D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1698931E-0BF1-4E41-BF09-EDD84AFF44D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B4BCCBC-DBB9-4DB6-A5F1-C59359892D9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B4BCCBC-DBB9-4DB6-A5F1-C59359892D9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B4BCCBC-DBB9-4DB6-A5F1-C59359892D9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B4BCCBC-DBB9-4DB6-A5F1-C59359892D9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Versioning_oM/Properties/AssemblyInfo.cs
+++ b/Versioning_oM/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Versioning_oM")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Versioning_oM")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3b4bccbc-dbb9-4db6-a5f1-c59359892d9f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.2.0.0")]

--- a/Versioning_oM/VersioningEvent.cs
+++ b/Versioning_oM/VersioningEvent.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Debugging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Versioning
+{
+    public class VersioningEvent : Event
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual string OldDocument { get; set; } = "";
+
+        public virtual string NewDocument { get; set; } = "";
+
+        public virtual string OldVersion { get; set; } = "";
+
+        public virtual string NewVersion { get; set; } = "";
+
+        public override EventType Type { get; set; } = EventType.Note;
+
+
+        /***************************************************/
+    }
+}
+
+

--- a/Versioning_oM/Versioning_42.json
+++ b/Versioning_oM/Versioning_42.json
@@ -1,0 +1,40 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Method": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Property": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "MessageForDeleted": {
+    "BH.oM.Versioning.NewVersion": "This type was only used in the inital testing of the versioning toolkit and is not necessary anymore.",
+    "BH.oM.Versioning.OldVersion": "This type was only used in the inital testing of the versioning toolkit and is not necessary anymore.",
+    "BH.oM.Versioning.Parent": "This type was only used in the inital testing of the versioning toolkit and is not necessary anymore."
+  },
+  "MessageForNoUpgrade": {
+
+  }
+}

--- a/Versioning_oM/Versioning_oM.csproj
+++ b/Versioning_oM/Versioning_oM.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Versioning_oM/Versioning_oM.csproj
+++ b/Versioning_oM/Versioning_oM.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3B4BCCBC-DBB9-4DB6-A5F1-C59359892D9F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.oM.Versioning</RootNamespace>
+    <AssemblyName>Versioning_oM</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VersioningEvent.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BHoM\BHoM.csproj">
+      <Project>{94D88927-62A2-48FC-8EFE-D139B67A3373}</Project>
+      <Name>BHoM</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Reflection_oM\Reflection_oM.csproj">
+      <Project>{29E6DCD7-270A-45CC-AC0B-6C024287645E}</Project>
+      <Name>Reflection_oM</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Versioning_42.json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
### NOTE: Depends on 

https://github.com/BHoM/Versioning_Toolkit/pull/159
  
### Issues addressed by this PR

This PR is done within the context of solving this issue: https://github.com/BHoM/BHoM_UI/issues/389

The reason for adding this project is to store the new VersioningEvent class that will be used to collect the list of all upgrades that occurred on BHoM objects and components.


### Test files
This can be tested within the context of the related PR in the BHoM Engine repo or with the related PR in the BHoM_UI.

