### PR TITLE
MEP_oM: Add new fitting object

### DIFF
--- a/MEP_oM/Enums/FittingType.cs
+++ b/MEP_oM/Enums/FittingType.cs
@@ -30,18 +30,31 @@ namespace BH.oM.MEP.Enums
     public enum FittingType
     {
         Undefined,
+        [Description("A fitting that allows you to change the size/shape of the linear MEP segment at a given juncture.")]
         Adaptor,
+        [Description("A fitting that is placed at the end of a linear MEP segment.")]
         Cap,
+        [Description("A fitting that joins two linear MEP segments of the same size and shape.")]
         Coupling,
+        [Description("A fitting that physically connects four different linear MEP segments, each at 90-degree angles.")]
         Cross,
+        [Description("A fitting that physically connects two different linear MEP segments, and re-directs the segment at a 30,45,60 or 90-degree angle.")]
         Elbow,
+        [Description("A fitting that allows you to change the size of the linear MEP segment at a given juncture, and gives additional reinforcement to both segments.")]
         Olet,
+        [Description("A fitting that is placed at the end of a linear MEP segment, allowing future access for maintenance purposes (clean out).")]
         Plug,
+        [Description("A fitting that allows you to change the size of the linear MEP segment at a given juncture.")]
         Reducer,
+        [Description("A fitting that keeps the main linear MEP segment size the same and allows a 45-degree transition to a 90-degree branch.")]
         Tap,
+        [Description("A fitting that allows you to change size and/or shape along the main linear MEP segment .")]
         Transition,
+        [Description("A fitting that keeps the main linear MEP segment size the same and allows a branch at a 90-degree angle.")]
         Tee,
+        [Description("A fitting that joins two linear MEP segments of the same size and shape, of which each end can be unscrewed independently.")]
         Union,
+        [Description("A fitting that joins three linear MEP segments of differing sizes and shapes, also known as pants.")]
         Wye
     }
 

--- a/MEP_oM/Enums/FittingType.cs
+++ b/MEP_oM/Enums/FittingType.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
@@ -20,32 +20,27 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.ComponentModel;
 
-using BH.oM.Base;
-using BH.oM.Geometry;
-
-namespace BH.oM.MEP.System.ConnectionProperties
+namespace BH.oM.MEP.Enums
 {
-    [Description("Base interface for MEP physical connection properties.")]
-    public interface IConnectionProperty : IBHoMObject
+    /***************************************************/
+
+    [Description("A type of fitting used to transition from one segment of linear MEP object to another (cable trays, ducts or pipes)")]
+    public enum FittingType
     {
-        /***************************************************/
-        /****                 Properties                ****/
-        /***************************************************/
-
-        [Description("The point at which the Connector object begins.")]
-        Point StartPoint { get; set; }
-
-        [Description("The point at which the Connector bject ends.")]
-        Point EndPoint { get; set; }
-
-        /***************************************************/
+        Undefined,
+        Adaptor,
+        Cap,
+        Coupling,
+        Cross,
+        Elbow,
+        Olet,
+        Plug,
+        Reducer,
+        Tee,
+        Union
     }
-}
 
+    /***************************************************/
+}

--- a/MEP_oM/Enums/FittingType.cs
+++ b/MEP_oM/Enums/FittingType.cs
@@ -26,12 +26,12 @@ namespace BH.oM.MEP.Enums
 {
     /***************************************************/
 
-    [Description("A type of fitting used to transition from one segment of linear MEP object to another (cable trays, ducts or pipes)")]
+    [Description("A type of fitting used to transition from one segment of linear MEP object to another.")]
     public enum FittingType
     {
         Undefined,
         [Description("A fitting that allows you to change the size/shape of the linear MEP segment at a given juncture.")]
-        Adaptor,
+        Adapter,
         [Description("A fitting that is placed at the end of a linear MEP segment.")]
         Cap,
         [Description("A fitting that joins two linear MEP segments of the same size and shape.")]

--- a/MEP_oM/Enums/FittingType.cs
+++ b/MEP_oM/Enums/FittingType.cs
@@ -38,8 +38,11 @@ namespace BH.oM.MEP.Enums
         Olet,
         Plug,
         Reducer,
+        Tap,
+        Transition,
         Tee,
-        Union
+        Union,
+        Wye
     }
 
     /***************************************************/

--- a/MEP_oM/MEP_oM.csproj
+++ b/MEP_oM/MEP_oM.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Enums\DamperType.cs" />
+    <Compile Include="Enums\FittingType.cs" />
     <Compile Include="Enums\ValveType.cs" />
     <Compile Include="Enums\FireAlarmDeviceType.cs" />
     <Compile Include="Enums\ElectricalFixtureType.cs" />
@@ -54,8 +55,6 @@
     <Compile Include="Fixtures\PlumbingFixture.cs" />
     <Compile Include="Fragments\PlumbingLoadingFixtureUnitFragment.cs" />
     <Compile Include="Fragments\PlumbingFlowFragment.cs" />
-    <Compile Include="System\ConnectionProperties\CableTrayConnectionProperty.cs" />
-    <Compile Include="System\ConnectionProperties\IConnectionProperty.cs" />
     <Compile Include="System\CableTray.cs" />
     <Compile Include="Fixtures\AirTerminal.cs" />
     <Compile Include="Fixtures\PlumbingFixtureFlow.cs" />
@@ -67,6 +66,7 @@
     <Compile Include="System\Dampers\Damper.cs" />
     <Compile Include="System\Dampers\VolumeDamper.cs" />
     <Compile Include="System\Duct.cs" />
+    <Compile Include="System\Fittings\Fitting.cs" />
     <Compile Include="System\IFlow.cs" />
     <Compile Include="System\MechanicalSystem.cs" />
     <Compile Include="System\Node.cs" />
@@ -106,9 +106,6 @@
     <Compile Include="System\SectionProperties\SectionProfile.cs" />
     <Compile Include="System\SectionProperties\WireSectionProperty.cs" />
     <Compile Include="Enums\PipeTypes.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="System\Fittings\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Analytical_oM\Analytical_oM.csproj">

--- a/MEP_oM/System/CableTray.cs
+++ b/MEP_oM/System/CableTray.cs
@@ -24,7 +24,6 @@ using System.ComponentModel;
 using BH.oM.Base;
 using BH.oM.MEP.System.SectionProperties;
 using BH.oM.Dimensional;
-using BH.oM.MEP.System.ConnectionProperties;
 using BH.oM.Quantities.Attributes;
 using BH.oM.Geometry;
 
@@ -45,9 +44,6 @@ namespace BH.oM.MEP.System
 
         [Description("The Cable Tray section property defines the shape (rectangular) and its associated properties (height, width, material, thickness/gauge).")]
         public virtual CableTraySectionProperty SectionProperty { get; set; } = null;
-
-        [Description("The Cable Tray connections properties, such as if it's connected and to what.")]
-        public virtual CableTrayConnectionProperty ConnectionProperty { get; set; } = null;
 
         [Angle]
         [Description("This is the Cable Tray's planometric orientation angle (the rotation around its central axis).")]

--- a/MEP_oM/System/Fittings/Fitting.cs
+++ b/MEP_oM/System/Fittings/Fitting.cs
@@ -20,36 +20,30 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using BH.oM.Geometry;
 using BH.oM.Base;
-using BH.oM.MEP.System.ConnectionProperties;
+using BH.oM.Dimensional;
+using BH.oM.Geometry;
+using BH.oM.MEP.Enums;
 
-namespace BH.oM.MEP.System.ConnectionProperties
+namespace BH.oM.MEP.System.Fittings
 {
-    [Description("A Cable Tray connection property to store information about its physical connectors.")]
-    public class CableTrayConnectionProperty : BHoMObject, IConnectionProperty
+    [Description("A fitting object used to describe interfaces between or along linear MEP elements.")]
+    public class Fitting : BHoMObject, IElement0D
     {
         /***************************************************/
         /****                 Properties                ****/
         /***************************************************/
 
-        [Description("The point at which the Connector object begins.")]
-        public virtual Point StartPoint { get; set; }
+        [Description("The point represented as a node at which the Fitting occurs.")]
+        public virtual Point Location { get; set; } = null;
+        
+        [Description("The points represented as nodes at which the Fitting physically connects to other MEP segments.")]
+        public virtual List<Point> ConnectionsLocation { get; set; } = null;
 
-        [Description("The point at which the Connector bject ends.")]
-        public virtual Point EndPoint { get; set; }
-
-        [Description("Whether the start point of the Cable Tray is connected to another segment or not.")]
-        public virtual bool IsStartConnected { get; set; }
-
-        [Description("Whether the end point of the Cable Tray is connected to another segment or not.")]
-        public virtual bool IsEndConnected { get; set; }       
+        [Description("The type of fitting connected to an element.")]
+        public virtual FittingType Type { get; set; } = FittingType.Undefined;
 
         /***************************************************/
     }

--- a/MEP_oM/System/Fittings/Fitting.cs
+++ b/MEP_oM/System/Fittings/Fitting.cs
@@ -36,10 +36,10 @@ namespace BH.oM.MEP.System.Fittings
         /****                 Properties                ****/
         /***************************************************/
 
-        [Description("The point represented as a node at which the Fitting occurs.")]
+        [Description("The point at which the Fitting occurs.")]
         public virtual Point Location { get; set; } = null;
         
-        [Description("The points represented as nodes at which the Fitting physically connects to other MEP segments.")]
+        [Description("The points at which the Fitting physically connects to other MEP segments.")]
         public virtual List<Point> ConnectionsLocation { get; set; } = null;
 
         [Description("The type of fitting connected to an element.")]

--- a/MEP_oM/Versioning_43.json
+++ b/MEP_oM/Versioning_43.json
@@ -1,13 +1,19 @@
 ﻿{
   "Namespace": {
     "ToNew": {
-	"BH.oM.Geometry.ShapeProfiles" : "BH.oM.Spatial.ShapeProfiles"
     },
     "ToOld": {
-	"BH.oM.Spatial.ShapeProfiles" : "BH.oM.Geometry.ShapeProfiles"
     }
   },
   "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Method": {
     "ToNew": {
 
     },
@@ -22,5 +28,11 @@
     "ToOld": {
 
     }
+  },
+  "MessageForDeleted": {
+    "BH.oM.MEP.System.ConnectionProperties.CableTrayConnectionProperty": "This object has been removed as the updates to the CableTray object have made this unnecessary."
+  },
+  "MessageForNoUpgrade": {
+
   }
 }

--- a/MEP_oM/Versioning_43.json
+++ b/MEP_oM/Versioning_43.json
@@ -1,0 +1,26 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+	"BH.oM.Geometry.ShapeProfiles" : "BH.oM.Spatial.ShapeProfiles"
+    },
+    "ToOld": {
+	"BH.oM.Spatial.ShapeProfiles" : "BH.oM.Geometry.ShapeProfiles"
+    }
+  },
+  "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Property": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1034 

Adds a generic fitting object with basic properties and removes connection properties.


### Test files
[Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%2FMEP%5FoM%2F%231034%2DAddGenericFittingObject)


### Changelog
Added `BH.oM.MEP.System.Fittings.Fitting`
Added `BH.oM.MEP.Enum.FittingType`
Modified `BH.oM.MEP.System.CableTray`
Removed `BH.oM.MEP.System.ConnectionProperties.IConnectionProperty`
Removed `BH.oM.MEP.System.ConnectionProperties.CableTrayConnectionProperty`
