### PR TITLE
Architecture_oM: IElement0D implemented by BuildersWork.Opening

### DIFF
--- a/Architecture_oM/BuildersWork/Opening.cs
+++ b/Architecture_oM/BuildersWork/Opening.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Base;
+using BH.oM.Dimensional;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Quantities.Attributes;
 using BH.oM.Spatial.ShapeProfiles;
@@ -29,7 +30,7 @@ using System.ComponentModel;
 namespace BH.oM.Architecture.BuildersWork
 {
     [Description("Object representing a builders work opening as an entity independent of its host.")]
-    public class Opening : BHoMObject
+    public class Opening : BHoMObject, IElement0D
     {
         /***************************************************/
         /****                Properties                 ****/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1257

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/BHoM_Engine/pull/2572


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
I was considering between different numbers of dimensions to be applied, but finally I came to a conclusion that the closest concept is 0D since the location of the opening is represented by `Cartesian`, ergo its position in space is a point. Happy to hear others' opinion! @rolyhudson @al-fisher @tiagogrossi @kayleighhoude @michaelhoehn 