### PR TITLE
BHoM: Removed GetShallowClone method from IBHoMObject and BHoMObject

### DIFF
--- a/BHoM/BHoMObject.cs
+++ b/BHoM/BHoMObject.cs
@@ -40,33 +40,6 @@ namespace BH.oM.Base
         public virtual HashSet<string> Tags { get; set; } = new HashSet<string>();
 
         public virtual Dictionary<string, object> CustomData { get; set; } = new Dictionary<string, object>();
-
-
-        /***************************************************/
-        /**** Public Local Methods                      ****/
-        /***************************************************/
-
-        public IBHoMObject GetShallowClone(bool newGuid = false)
-        {
-            BHoMObject obj = (BHoMObject)this.MemberwiseClone();
-
-            if (CustomData != null)
-                obj.CustomData = new Dictionary<string, object>(CustomData);
-            else
-                obj.CustomData = new Dictionary<string, object>();
-
-            if (Tags != null)
-                obj.Tags = new HashSet<string>(Tags);
-            else
-                obj.Tags = new HashSet<string>();
-
-            if (newGuid)
-                obj.BHoM_Guid = Guid.NewGuid();
-
-            return obj;
-        }
-
-        /***************************************************/
     }
 }
 

--- a/BHoM/Interface/IBHoMObject.cs
+++ b/BHoM/Interface/IBHoMObject.cs
@@ -36,8 +36,6 @@ namespace BH.oM.Base
         HashSet<string> Tags { get; set; }
 
         Dictionary<string, object> CustomData { get; set; }
-
-        IBHoMObject GetShallowClone(bool newGuid = false);
     }
 }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1264

<!-- Add short description of what has been fixed -->
Following https://github.com/BHoM/admin/issues/9#issuecomment-886638611, all references to the method `GetShallowClone` of BHoMObject have been removed in favour of Engine methods `DeepClone` and `ShallowClone` that do not require implementation.

This has to be merged in parallel with the PR that targets https://github.com/BHoM/XML_Toolkit/issues/532 so that also the last remaining implementation of a BHoMObject's GetShallowClone is removed.

### Test files
<!-- Link to test files to validate the proposed changes -->
As part of https://github.com/BHoM/admin/issues/9#issuecomment-886638611, all references to the method have been removed. Only test needed is for everything to compile successfully.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->