### PR TITLE
BHoM: IPersistentAdapterId not to require set on PersistentId

### DIFF
--- a/BHoM/Interface/IPersistentAdapterId.cs
+++ b/BHoM/Interface/IPersistentAdapterId.cs
@@ -29,7 +29,7 @@ namespace BH.oM.Base
     public interface IPersistentAdapterId : IFragment
     {
         [Description("Globally unique and generated upon object creation in the external software; it never changes throughout the life of the object.")]
-        object PersistentId { get; set; }
+        object PersistentId { get; }
     }
 }
 

--- a/BHoM/Interface/IPersistentAdapterId.cs
+++ b/BHoM/Interface/IPersistentAdapterId.cs
@@ -26,9 +26,12 @@ using System.ComponentModel;
 
 namespace BH.oM.Base
 {
+    [Description("Requires a Fragment to contain a PersistentId, imported through an Adapter, that can be used to track an object.")]
     public interface IPersistentAdapterId : IFragment
     {
-        [Description("Globally unique and generated upon object creation in the external software; it never changes throughout the life of the object.")]
+        [Description("Persistent identifier of the object in the external software, imported through an Adapter." +
+            "'Persistent' means that the identifier must be: globally unique and referring to exactly one object in the external software; generated once upon object creation in the external software; never changing throughout the life of the object in the external software." +
+            "If all these requirements are satisfied, the PersistentId imported from the external software can be used for Diffing purposes.")]
         object PersistentId { get; }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1266

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->