### PR TITLE
Analytical_oM: Reformulate the IResult interface

### DIFF
--- a/Analytical_oM/Analytical_oM.csproj
+++ b/Analytical_oM/Analytical_oM.csproj
@@ -68,6 +68,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Results\IMeshElementResult.cs" />
     <Compile Include="Results\IMeshResult.cs" />
+    <Compile Include="Results\IAnalysisResult.cs" />
+    <Compile Include="Results\ITimeStepResult.cs" />
+    <Compile Include="Results\IResultCase.cs" />
+    <Compile Include="Results\IObjectIdResult.cs" />
     <Compile Include="Results\IResult.cs" />
     <Compile Include="Results\IResultCollection.cs" />
     <Compile Include="Results\ShortestPathResult.cs" />

--- a/Analytical_oM/Analytical_oM.csproj
+++ b/Analytical_oM/Analytical_oM.csproj
@@ -70,7 +70,7 @@
     <Compile Include="Results\IMeshResult.cs" />
     <Compile Include="Results\IAnalysisResult.cs" />
     <Compile Include="Results\ITimeStepResult.cs" />
-    <Compile Include="Results\IResultCase.cs" />
+    <Compile Include="Results\ICasedResult.cs" />
     <Compile Include="Results\IObjectIdResult.cs" />
     <Compile Include="Results\IResult.cs" />
     <Compile Include="Results\IResultCollection.cs" />

--- a/Analytical_oM/Results/IAnalysisResult.cs
+++ b/Analytical_oM/Results/IAnalysisResult.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Analytical.Results
 {
-    public interface IAnalysisResult : IObjectIdResult, IResultCase, ITimeStepResult
+    public interface IAnalysisResult : IObjectIdResult, ICasedResult, ITimeStepResult
     {
 
     }

--- a/Analytical_oM/Results/IAnalysisResult.cs
+++ b/Analytical_oM/Results/IAnalysisResult.cs
@@ -20,51 +20,18 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-
-using BH.oM.Geometry;
-using System.ComponentModel;
+using BH.oM.Base;
 using System;
-using BH.oM.Analytical.Results;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace BH.oM.Humans.ViewQuality
+namespace BH.oM.Analytical.Results
 {
-    public abstract class ViewQualityResult : IAnalysisResult
+    public interface IAnalysisResult : IObjectIdResult, IResultCase, ITimeStepResult
     {
-        /***************************************************/
-        /**** Properties                                ****/
-        /***************************************************/
 
-        public virtual IComparable ObjectId { get; set; } = "";
-
-        public virtual IComparable ResultCase { get; set; } = "";
-
-        public virtual double TimeStep { get; set; } = 0.0;
-
-        /***************************************************/
-        /**** IComparable Interface                     ****/
-        /***************************************************/
-
-        public int CompareTo(IResult other)
-        {
-            ViewQualityResult otherRes = other as ViewQualityResult;
-
-            if (otherRes == null)
-                return this.GetType().Name.CompareTo(other.GetType().Name);
-
-            int n = this.ObjectId.CompareTo(otherRes.ObjectId);
-            if (n == 0)
-            {
-                int l = this.ResultCase.CompareTo(otherRes.ResultCase);
-                return l == 0 ? this.TimeStep.CompareTo(otherRes.TimeStep) : l;
-            }
-            else
-            {
-                return n;
-            }
-
-        }
-
-        /***************************************************/
     }
 }
 

--- a/Analytical_oM/Results/ICasedResult.cs
+++ b/Analytical_oM/Results/ICasedResult.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Analytical.Results
 {
-    public interface IResultCase : IResult
+    public interface ICasedResult : IResult
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Analytical_oM/Results/IMeshElementResult.cs
+++ b/Analytical_oM/Results/IMeshElementResult.cs
@@ -30,7 +30,7 @@ using System.ComponentModel;
 namespace BH.oM.Analytical.Results
 {
     [Description("Base interface for mesh element results. This is the result for a single discrete node or face of the mesh the result aligns with.")]
-    public interface IMeshElementResult : IResult
+    public interface IMeshElementResult : IAnalysisResult
     {
         [Description("ID of the Node in the mesh that this result belongs to.")]
         IComparable NodeId { get; }

--- a/Analytical_oM/Results/IMeshResult.cs
+++ b/Analytical_oM/Results/IMeshResult.cs
@@ -30,7 +30,7 @@ using System.ComponentModel;
 namespace BH.oM.Analytical.Results
 {
     [Description("Base interface for any Mesh result class which is a collection of discrete MeshElementResults.")]
-    public interface IMeshResult<T> : IResultCollection<T> where T : IMeshElementResult
+    public interface IMeshResult<T> : IAnalysisResult, IResultCollection<T> where T : IMeshElementResult
     {
 
     }

--- a/Analytical_oM/Results/IObjectIdResult.cs
+++ b/Analytical_oM/Results/IObjectIdResult.cs
@@ -20,49 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-
-using BH.oM.Geometry;
-using System.ComponentModel;
+using BH.oM.Base;
 using System;
-using BH.oM.Analytical.Results;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace BH.oM.Humans.ViewQuality
+namespace BH.oM.Analytical.Results
 {
-    public abstract class ViewQualityResult : IAnalysisResult
+    public interface IObjectIdResult : IResult
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        public virtual IComparable ObjectId { get; set; } = "";
-
-        public virtual IComparable ResultCase { get; set; } = "";
-
-        public virtual double TimeStep { get; set; } = 0.0;
-
-        /***************************************************/
-        /**** IComparable Interface                     ****/
-        /***************************************************/
-
-        public int CompareTo(IResult other)
-        {
-            ViewQualityResult otherRes = other as ViewQualityResult;
-
-            if (otherRes == null)
-                return this.GetType().Name.CompareTo(other.GetType().Name);
-
-            int n = this.ObjectId.CompareTo(otherRes.ObjectId);
-            if (n == 0)
-            {
-                int l = this.ResultCase.CompareTo(otherRes.ResultCase);
-                return l == 0 ? this.TimeStep.CompareTo(otherRes.TimeStep) : l;
-            }
-            else
-            {
-                return n;
-            }
-
-        }
+        IComparable ObjectId { get; }
 
         /***************************************************/
     }

--- a/Analytical_oM/Results/IResult.cs
+++ b/Analytical_oM/Results/IResult.cs
@@ -35,11 +35,6 @@ namespace BH.oM.Analytical.Results
         /**** Properties                                ****/
         /***************************************************/
 
-        IComparable ObjectId { get; }
-
-        IComparable ResultCase { get; }
-
-        double TimeStep { get; }
 
         /***************************************************/
     }

--- a/Analytical_oM/Results/IResultCase.cs
+++ b/Analytical_oM/Results/IResultCase.cs
@@ -20,49 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-
-using BH.oM.Geometry;
-using System.ComponentModel;
+using BH.oM.Base;
 using System;
-using BH.oM.Analytical.Results;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace BH.oM.Humans.ViewQuality
+namespace BH.oM.Analytical.Results
 {
-    public abstract class ViewQualityResult : IAnalysisResult
+    public interface IResultCase : IResult
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        public virtual IComparable ObjectId { get; set; } = "";
-
-        public virtual IComparable ResultCase { get; set; } = "";
-
-        public virtual double TimeStep { get; set; } = 0.0;
-
-        /***************************************************/
-        /**** IComparable Interface                     ****/
-        /***************************************************/
-
-        public int CompareTo(IResult other)
-        {
-            ViewQualityResult otherRes = other as ViewQualityResult;
-
-            if (otherRes == null)
-                return this.GetType().Name.CompareTo(other.GetType().Name);
-
-            int n = this.ObjectId.CompareTo(otherRes.ObjectId);
-            if (n == 0)
-            {
-                int l = this.ResultCase.CompareTo(otherRes.ResultCase);
-                return l == 0 ? this.TimeStep.CompareTo(otherRes.TimeStep) : l;
-            }
-            else
-            {
-                return n;
-            }
-
-        }
+        IComparable ResultCase { get; }
 
         /***************************************************/
     }

--- a/Analytical_oM/Results/ITimeStepResult.cs
+++ b/Analytical_oM/Results/ITimeStepResult.cs
@@ -20,49 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-
-using BH.oM.Geometry;
-using System.ComponentModel;
+using BH.oM.Base;
 using System;
-using BH.oM.Analytical.Results;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace BH.oM.Humans.ViewQuality
+namespace BH.oM.Analytical.Results
 {
-    public abstract class ViewQualityResult : IAnalysisResult
+    public interface ITimeStepResult : IResult
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        public virtual IComparable ObjectId { get; set; } = "";
-
-        public virtual IComparable ResultCase { get; set; } = "";
-
-        public virtual double TimeStep { get; set; } = 0.0;
-
-        /***************************************************/
-        /**** IComparable Interface                     ****/
-        /***************************************************/
-
-        public int CompareTo(IResult other)
-        {
-            ViewQualityResult otherRes = other as ViewQualityResult;
-
-            if (otherRes == null)
-                return this.GetType().Name.CompareTo(other.GetType().Name);
-
-            int n = this.ObjectId.CompareTo(otherRes.ObjectId);
-            if (n == 0)
-            {
-                int l = this.ResultCase.CompareTo(otherRes.ResultCase);
-                return l == 0 ? this.TimeStep.CompareTo(otherRes.TimeStep) : l;
-            }
-            else
-            {
-                return n;
-            }
-
-        }
+        double TimeStep { get; }
 
         /***************************************************/
     }

--- a/Analytical_oM/Results/ShortestPathResult.cs
+++ b/Analytical_oM/Results/ShortestPathResult.cs
@@ -33,7 +33,7 @@ using BH.oM.Geometry;
 namespace BH.oM.Analytical.Elements
 {
     [Description("Results associated with the computation of shortest paths.")]
-    public class ShortestPathResult : IResult, IImmutable
+    public class ShortestPathResult : IAnalysisResult, IImmutable
     {
         [Description("ID of the object that this result belongs to.")]
         public virtual IComparable ObjectId { get; }

--- a/Environment_oM/Results/Mesh/MeshElementResult.cs
+++ b/Environment_oM/Results/Mesh/MeshElementResult.cs
@@ -29,7 +29,7 @@ using System;
 namespace BH.oM.Environment.Results.Mesh
 {
     [Description("Base class for all discrete mesh element results, that is a result for an individual node. Stores all identifier information and how to sort the results in a collection")]
-    public abstract class MeshElementResult : IResult, IImmutable
+    public abstract class MeshElementResult : BH.oM.Analytical.Results.IAnalysisResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Environment_oM/Results/Mesh/MeshResult.cs
+++ b/Environment_oM/Results/Mesh/MeshResult.cs
@@ -31,7 +31,7 @@ using System;
 namespace BH.oM.Environment.Results.Mesh
 {
     [Description("Full collection of discrete results for an AnalysisGrid for a specific Analysis.")]
-    public class MeshResult : IResult, IResultCollection<MeshElementResult>, IImmutable
+    public class MeshResult : BH.oM.Analytical.Results.IAnalysisResult, IResultCollection<MeshElementResult>, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/LifeCycleAssessment_oM/Results/LifeCycleAssessmentElementResult.cs
+++ b/LifeCycleAssessment_oM/Results/LifeCycleAssessmentElementResult.cs
@@ -30,7 +30,7 @@ using System.ComponentModel;
 namespace BH.oM.LifeCycleAssessment.Results
 {
     [Description("Base class for a LifeCycleAssessment of a single object. This contains the total quantity of global warming potential, acidification potential, etc. for a whole project.")]
-    public abstract class LifeCycleAssessmentElementResult : IResult, IImmutable
+    public abstract class LifeCycleAssessmentElementResult : IAnalysisResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/LifeCycleAssessment_oM/Results/LifeCycleAssessmentResult.cs
+++ b/LifeCycleAssessment_oM/Results/LifeCycleAssessmentResult.cs
@@ -31,7 +31,7 @@ using System.Collections.ObjectModel;
 namespace BH.oM.LifeCycleAssessment.Results
 {
     [Description("Result class for a LifeCycleAssessment of a whole project. This is used to get the total quantity in terms of embodied carbon, acidification, etc. for a whole project.")]
-    public class LifeCycleAssessmentResult : IResult, IResultCollection<LifeCycleAssessmentElementResult>, IImmutable
+    public class LifeCycleAssessmentResult : IAnalysisResult, IResultCollection<LifeCycleAssessmentElementResult>, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/LifeCycleAssessment_oM/Results/ProjectLifeCycleAssessmentResult.cs
+++ b/LifeCycleAssessment_oM/Results/ProjectLifeCycleAssessmentResult.cs
@@ -29,7 +29,7 @@ using System.ComponentModel;
 namespace BH.oM.LifeCycleAssessment.Results
 {
     [Description("A collection of simplified project results commonly used for database collection.")]
-    public partial class ProjectLifeCycleAssessmentResult : IResult, IImmutable
+    public partial class ProjectLifeCycleAssessmentResult : IAnalysisResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Lighting_oM/Results/Mesh/MeshElementResult.cs
+++ b/Lighting_oM/Results/Mesh/MeshElementResult.cs
@@ -29,7 +29,7 @@ using System;
 namespace BH.oM.Lighting.Results.Mesh
 {
     [Description("Base class for all discrete mesh element results, that is a result for an individual node. Stores all identifier information and how to sort the results in a collection")]
-    public abstract class MeshElementResult : IResult, IImmutable
+    public abstract class MeshElementResult : IAnalysisResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Lighting_oM/Results/Mesh/MeshResult.cs
+++ b/Lighting_oM/Results/Mesh/MeshResult.cs
@@ -31,7 +31,7 @@ using System;
 namespace BH.oM.Lighting.Results.Mesh
 {
     [Description("Full collection of discrete results for an AnalysisGrid for a specific Analysis.")]
-    public class MeshResult : IResult, IResultCollection<MeshElementResult>, IImmutable
+    public class MeshResult : IAnalysisResult, IResultCollection<MeshElementResult>, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Structure_oM/Results/Bar Results/IBarDisplacement.cs
+++ b/Structure_oM/Results/Bar Results/IBarDisplacement.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 namespace BH.oM.Structure.Results
 {
     [Description("Base interface for bar displacements")]
-    public interface IBarDisplacement : IResult, IImmutable
+    public interface IBarDisplacement : IAnalysisResult, IImmutable
     {
         double UX { get; }
 

--- a/Structure_oM/Results/IStructuralResult.cs
+++ b/Structure_oM/Results/IStructuralResult.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 namespace BH.oM.Structure.Results
 {
     [Description("Base interface for all structural results. Adds ModeNumber as a property in addition to the one from the base IResult")]
-    public interface IStructuralResult : IResult, IImmutable
+    public interface IStructuralResult : IAnalysisResult, IImmutable
     {
         [Description("Positive index, starting at one. Only set for cases with modal outputs such as dynamic cases.")]
         int ModeNumber { get; }

--- a/Structure_oM/Results/Mesh/IMeshDisplacement.cs
+++ b/Structure_oM/Results/Mesh/IMeshDisplacement.cs
@@ -29,7 +29,7 @@ using BH.oM.Geometry;
 namespace BH.oM.Structure.Results
 {
     [Description("Base interface for mesh displacements")]
-    public interface IMeshDisplacement : IResult, IImmutable
+    public interface IMeshDisplacement : IAnalysisResult, IImmutable
     {
         double UXX { get; }
 

--- a/Structure_oM/Results/Mesh/MeshResult.cs
+++ b/Structure_oM/Results/Mesh/MeshResult.cs
@@ -32,7 +32,7 @@ using System.Linq;
 namespace BH.oM.Structure.Results
 {
     [Description("Full collection of discrete results for a Panel/FEMesh for a specific Loadcase or LoadCombination.")]
-    public class MeshResult : IResult, IMeshResult<MeshElementResult>, IStructuralResult, IImmutable
+    public class MeshResult : IAnalysisResult, IMeshResult<MeshElementResult>, IStructuralResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Structure_oM/Results/Nodal Results/INodeDisplacement.cs
+++ b/Structure_oM/Results/Nodal Results/INodeDisplacement.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 namespace BH.oM.Structure.Results
 {
     [Description("Base interface for node displacements")]
-    public interface INodeDisplacement: IResult, IImmutable
+    public interface INodeDisplacement: IAnalysisResult, IImmutable
     {
         double UX { get; }
 

--- a/Test_oM/Results/InputOutputComparisonDiffing.cs
+++ b/Test_oM/Results/InputOutputComparisonDiffing.cs
@@ -31,7 +31,7 @@ using BH.oM.Base;
 
 namespace BH.oM.Test.Results
 {
-    public class InputOutputComparisonDiffing : IResult, IImmutable
+    public class InputOutputComparisonDiffing : IAnalysisResult, IImmutable
     {
 
         /***************************************************/

--- a/Test_oM/Results/InputOutputComparisonSummary.cs
+++ b/Test_oM/Results/InputOutputComparisonSummary.cs
@@ -31,7 +31,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Test.Results
 {
-    public class InputOutputComparisonSummary : IResult, IImmutable
+    public class InputOutputComparisonSummary : IAnalysisResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/Test_oM/Results/InputOutputDifference.cs
+++ b/Test_oM/Results/InputOutputDifference.cs
@@ -31,7 +31,7 @@ using BH.oM.Base;
 
 namespace BH.oM.Test.Results
 {
-    public class InputOutputDifference : IResult, IImmutable
+    public class InputOutputDifference : IAnalysisResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
Closes #1278

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1278

<!-- Add short description of what has been fixed -->

The base IResult interface is now empty (does not require any specific property). In its stead, you can find:
- `IObjectIdResult`, that asks for an `ObjectId`
- `ICasedResult`, that asks for a `ResultCase`
- `ITimeStepResult`, that asks for a `TimeStep`
In addition, to maintain compatibility with all existing functionality, I added a `IAnalyticalResult` that implements all the three interfaces above, so it effectively replicates what `IResult` used to be. I modified all existing implementations of `IResult` to reference to `IAnalyticalResult` instead, so functionality wise we should look exactly the same as before.

The advantage of this approach is that you are no longer forced to implement all properties that `IResult` used to force you to implement, if they do not make sense. If it does not make sense for your result object to have `TimeStep` or `ResultCase`, for instance, then you can have it implement only `IObjectIdResult`.

More advantages are listed in https://github.com/BHoM/BHoM_Engine/pull/2604.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Modified `IResult` to become an empty interface (no required properties).
- Added `IObjectIdResult`, that asks for an `ObjectId`
- Added `ICasedResult`, that asks for a `ResultCase`
- Added `ITimeStepResult`, that asks for a `TimeStep`
- `IAnalyticalResult` was added; this replicates what the old `IResult` used to be, by implementing all the abovementioned interfaces. All existing implementations of `IResult` were modified to reference `IAnalyticalResult`, so we maintain existing functionality.

### Additional comments
<!-- As required -->
As discussed with @FraserGreenroyd , this PR has currently a failing code-compliance that is due to a check that was introduced after the failing object had been introduced. [This PR](https://github.com/BHoM/BHoM/pull/1077) added the object, but the check for Immutable constructors came in 2021, so it "passed" compliance because it wasn't seen before. The strategy would be to grant this PR dispensation on compliance, then to fix that issue separately.