### PR TITLE
Base_oM: Adding Enumeration object

### DIFF
--- a/BHoM/Enumeration.cs
+++ b/BHoM/Enumeration.cs
@@ -27,7 +27,7 @@ using System.Reflection;
 
 namespace BH.oM.Base
 {
-    public abstract class Enumeration : IObject, IComparable, IEnum // TODO: Fix serialisation so we can remove the inheritance from BHoMObject
+    public abstract class Enumeration : IObject, IEnum 
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -89,9 +89,9 @@ namespace BH.oM.Base
 
         /***************************************************/
 
-        public int CompareTo(object other)
+        public int CompareTo(IEnum other)
         {
-            return Value.CompareTo(((Enumeration)other)?.Value);
+            return Value.CompareTo(other?.Value);
         }
 
 

--- a/BHoM/Enumeration.cs
+++ b/BHoM/Enumeration.cs
@@ -91,7 +91,7 @@ namespace BH.oM.Base
 
         public int CompareTo(object other)
         {
-            return Value.CompareTo(((Enumeration)other).Value);
+            return Value.CompareTo(((Enumeration)other)?.Value);
         }
 
 

--- a/BHoM/Enumeration.cs
+++ b/BHoM/Enumeration.cs
@@ -1,0 +1,132 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace BH.oM.Base
+{
+    public abstract class Enumeration : IObject, IComparable, IEnum // TODO: Fix serialisation so we can remove the inheritance from BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string Value { get; private set; }
+
+        public string Description
+        {
+            get
+            {
+                return m_Description.Length > 0 ? m_Description : Value;
+            }
+            private set
+            {
+                m_Description = value;
+            }
+        }
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        protected Enumeration(string value, string description = "")
+        {
+            Value = value;
+            m_Description = description;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public override string ToString()
+        {
+            return Value;
+        }
+
+        /***************************************************/
+
+        public override bool Equals(object obj)
+        {
+            Enumeration otherValue = obj as Enumeration;
+            if (otherValue == null)
+                return false;
+
+            return GetType().Equals(obj.GetType())
+                && Value.Equals(otherValue.Value);
+        }  
+
+        /***************************************************/
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        /***************************************************/
+
+        public int CompareTo(object other)
+        {
+            return Value.CompareTo(((Enumeration)other).Value);
+        }
+
+
+        /***************************************************/
+        /**** Private Fields                            ****/
+        /***************************************************/
+
+        private string m_Description = "";
+
+
+        /***************************************************/
+        /**** Static Methods                            ****/
+        /***************************************************/
+
+        public static bool Equals(IEnum a, IEnum b)
+        {
+            if (a == null || b == null)
+                return false;
+
+            return a.GetType().Equals(b.GetType())
+                && a.Value.Equals(b.Value);
+        }
+
+        /***************************************************/
+
+        public static IEnumerable<T> GetAll<T>() where T : Enumeration
+        {
+            return typeof(T).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                     .Select(f => f.GetValue(null))
+                     .Cast<T>();
+        } 
+
+        /***************************************************/
+    }
+}
+
+
+

--- a/BHoM/Interface/IEnum.cs
+++ b/BHoM/Interface/IEnum.cs
@@ -26,7 +26,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Base
 {
-    public interface IEnum : IComparable
+    public interface IEnum : IComparable<IEnum>
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/BHoM/Interface/IEnum.cs
+++ b/BHoM/Interface/IEnum.cs
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.oM.Base
+{
+    public interface IEnum : IComparable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        string Value { get; }
+
+        string Description { get; }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        string ToString();
+
+        bool Equals(object obj);
+
+        int GetHashCode();
+
+        /***************************************************/
+    }
+}
+
+


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1293

See issue. Current implementation in the context of the Embodied Carbon toolkit


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Base_oM/%231294%20-%20Enumeration?csf=1&web=1&e=eX3XoG
You will need the following PRs to do the testing:
- https://github.com/BHoM/BHoM_Engine/pull/2637
- https://github.com/BHoM/Excel_Toolkit/pull/310
- https://github.com/BuroHappoldEngineering/EmbodiedCarbon_Toolkit/pull/1


### Additional comments
There's a lot that can be done to make the Enumerations more user friendly in the UI (e.g. make it behave exactly like a regular enum in the UI) but this PR is just about laying the foundation for this new type of object. It has been working great for me in the context of the Carbon calculator tool for all stages of workflow so I am pretty confident it is safe to merge. Make sure to play with the test file though.