### PR TITLE
BHoM: ISettings to implement IObject

### DIFF
--- a/BHoM/Interface/ISettings.cs
+++ b/BHoM/Interface/ISettings.cs
@@ -31,7 +31,7 @@ using System.Threading.Tasks;
 namespace BH.oM.Base
 {
     [Description("Toolkit Settings that need to be saved permanently.")]
-    public interface ISettings
+    public interface ISettings : IObject
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1297

<!-- Add short description of what has been fixed -->

Enables things like serialisation for objects that _only_ implements the `ISettings` interface, without also being a `BHoMObject`.

Should not change the behaviour of the pre-existing `ISettings` as they all currently are `BHoMObjects` and get the `IObject` from there.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->