### PR TITLE
Diffing_oM: reworked `Diff` class; added `ComparisonInclusion` and a `ComparisonConfig` base class

### DIFF
--- a/BHoM/BaseComparisonConfig.cs
+++ b/BHoM/BaseComparisonConfig.cs
@@ -1,0 +1,88 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.oM.Base
+{
+    [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
+    public abstract class BaseComparisonConfig : IObject
+    {
+        [Description("Names of properties you want to disregard in defining the uniqueness of an object. `BHoM_Guid` is always added by default. Supports * wildcard (see examples below)."
+            + "\nExamples of valid values: `BHoM_Guid`, `StartNode`, `Bar.StartNode.Point.X`, `Bar.*.Point.Y`")]
+        public virtual List<string> PropertyExceptions { get; set; } = new List<string>() { };
+
+        [Description("Any corresponding namespace is ignored. E.g. `BH.oM.Structure`.")]
+        public virtual List<string> NamespaceExceptions { get; set; } = new List<string>();
+
+        [Description("Any corresponding type is ignored. E.g. `typeof(Guid)`.")]
+        public virtual List<Type> TypeExceptions { get; set; } = new List<Type>();
+
+        [Description("Keys of the BHoMObjects' CustomData dictionary that should be exclusively included. Adding keys to this List will exclude any key that is not in this List. I.e. for every object, if it has CustomData keys present in this List, we then exclude any other CustomData key found in it.")]
+        public virtual List<string> CustomdataKeysToInclude { get; set; } = new List<string>() { };
+
+        [Description("Keys of the BHoMObjects' CustomData dictionary that should be ignored.\nBy default it includes `RenderMesh`.")]
+        public virtual List<string> CustomdataKeysExceptions { get; set; } = new List<string>() { "RenderMesh" };
+
+        [Description("If any name is specified here, only properties corresponding to that name will be considered in the hash." +
+           "\nE.g. For BH.oM.Structure.Elements.Bar, specifying `StartNode` will only check if that property is different." +
+           "\nYou can List specify sub-properties or partial paths, e.g. `StartNode.Name` or `*.Name`.")]
+        public virtual List<string> PropertiesToConsider { get; set; } = new List<string>();
+
+        [Description("If any property is nested into the object over that level, it is ignored. Useful to limit the runtime." +
+            "Defaults to unlimited.")]
+        public virtual int MaxNesting { get; set; } = int.MaxValue;
+
+        [Description("Sets the maximum number of property differences to be determined before stopping. Useful to limit the runtime." +
+            "Defaults to unlimited.")]
+        public virtual int MaxPropertyDifferences { get; set; } = int.MaxValue;
+
+        [Description("Numeric tolerance for property values, applied to all numerical properties. Defaults to double.MinValue: no rounding applied." +
+            "\nApplies rounding for numbers smaller than this." +
+            "\nYou can override on a per-property basis by using `PropertyNumericTolerances`." +
+            "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
+        public virtual double NumericTolerance { get; set; } = double.MinValue;
+
+        [Description("Number of significant figures allowed for numerical data." +
+            "\nDefaults to `int.MaxValue`: no approximation applied." +
+            "\nYou can override on a per-property basis by using `PropertySignificantDigits`." +
+            "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
+        public virtual int SignificantFigures { get; set; } = int.MaxValue;
+
+        [Description("Tolerance used for individual properties. When computing Hash or the property Diffing, if the analysed property name is found in this collection, the corresponding tolerance is applied." +
+            "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
+            "\nIf a match is found, this take precedence over the global `NumericTolerance`." +
+            "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
+        public virtual HashSet<NamedNumericTolerance> PropertyNumericTolerances { get; set; } = new HashSet<NamedNumericTolerance>();
+
+        [Description("Number of significant figures allowed for numerical data on a per-property base. " +
+             "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
+             "\nIf a match is found, this take precedence over the global `SignificantFigures`." +
+             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
+        public virtual HashSet<NamedSignificantFigures> PropertySignificantFigures { get; set; } = new HashSet<NamedSignificantFigures>();
+
+    }
+}
+
+

--- a/BHoM/ComparisonInclusion.cs
+++ b/BHoM/ComparisonInclusion.cs
@@ -20,15 +20,31 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace BH.oM.Base
 {
-    [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
-    public class ComparisonConfig : BaseComparisonConfig
+    [Description("Information about how an object's property should be included or not in a comparison (i.e. when computing an object's Hash or Diffing)." +
+        "A ComparisonInclusion object is returned by the extension method of the same name (which is invoked automatically when Hashing or Diffing)." +
+        "The ComparisonInclusion() method can be implemented in specific Toolkits/namespaces to customise the comparison (i.e. with Toolkit-specific information which would be otherwise unavailable to the base Hash/Diffing)." +
+        "See the wiki for examples of this.")]
+    public class ComparisonInclusion : IObject
     {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Whether the current property should be included or not in the comparison (i.e. Hash or Diffing).")]
+        public virtual bool Include { get; set; } = true;
+
+        [Description("A custom DisplayName can be set so changes detected will be displayed with this name instead of the default Property Name.")]
+        public virtual string DisplayName { get; set; }
     }
 }
 

--- a/BHoM/NamedNumericTolerance.cs
+++ b/BHoM/NamedNumericTolerance.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
@@ -20,16 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace BH.oM.Base
 {
-    [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
-    public class ComparisonConfig : BaseComparisonConfig
+    [Description("Tolerance used for specific numerical objects or properties with a specific name." +
+        "When computing Hash or the property Diffing, if the analysed object or property name is found in this collection, the corresponding tolerance is considered.")]
+    public class NamedNumericTolerance : IObject
     {
+        [Description("When computing Hash or the property Diffing, if the analysed object name or property name is found in this collection, the corresponding tolerance is applied." +
+            "\nSupports * wildcard in the property name matching. Examples: " +
+            "\n\t - `BH.oM.Geometry.Vector`: applies the corresponding tolerance to all numerical properties of Vectors, i.e. X, Y, Z;" +
+            "\n\t - `BH.oM.Structure.Elements.*.Position`: applies the corresponding tolerance to all numerical properties of properties named `Position` under any Structural Element," +
+            "\n\t    e.g. Bar.Position.X, Bar.Position.Y, Bar.Position.Z. and at the same time also Node.Position.X, Node.Position.Y, Node.Position.Z.")]
+        public virtual string Name { get; set; }
+
+        [Description("Numeric tolerance. Applies rounding for numbers smaller than this. Defaults to 1E-12.")]
+        public virtual double Tolerance { get; set; } = 1e-12;
     }
 }
-
-

--- a/BHoM/NamedSignificantFigures.cs
+++ b/BHoM/NamedSignificantFigures.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
@@ -20,16 +20,22 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace BH.oM.Base
 {
-    [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
-    public class ComparisonConfig : BaseComparisonConfig
+    [Description("Significant digits used for specific numerical objects or properties with a specific name." +
+        "When computing Hash or the property Diffing, if the analysed object or property name is found in this collection, the corresponding SignificantFigures approximation is applied.")]
+    public class NamedSignificantFigures : IObject
     {
+        [Description("When computing Hash or the property Diffing, if the analysed object name or property name is found in this collection, the corresponding SignificantFigures approximation is applied." +
+            "\nSupports * wildcard in the property name matching. Examples: " +
+            "\n\t - `BH.oM.Geometry.Vector`: applies the corresponding tolerance to all numerical properties of Vectors, i.e. X, Y, Z;" +
+            "\n\t - `BH.oM.Structure.Elements.*.Position`: applies the corresponding tolerance to all numerical properties of properties named `Position` under any Structural Element," +
+            "\n\t    e.g. Bar.Position.X, Bar.Position.Y, Bar.Position.Z. and at the same time also Node.Position.X, Node.Position.Y, Node.Position.Z.")]
+        public virtual string Name { get; set; }
+
+        [Description("Significant figures to be taken for this property.")]
+        public virtual int SignificantFigures { get; set; } = int.MaxValue;
     }
 }
-
-

--- a/BHoM/Versioning_50.json
+++ b/BHoM/Versioning_50.json
@@ -1,0 +1,10 @@
+﻿{
+    "Property": {
+    },
+    "MessageForDeleted": {
+        "BH.oM.Base.ComparisonFunctions": "This object's functionality has been replaced by the ComparisonInclusion() extension method (to be implemented in specific Toolkits that need it; see e.g. Revit) and object."
+    },
+    "MessageForNoUpgrade": {
+        "BH.oM.Base.ComparisonConfig": "The object has been modified in a way that automatic conversion is no possible. Please re-create the object and refer to the new inputs descriptions."
+    }
+}

--- a/Diffing_oM/Delta.cs
+++ b/Diffing_oM/Delta.cs
@@ -38,24 +38,24 @@ namespace BH.oM.Diffing
         /**** Properties                                ****/
         /***************************************************/
         [Description("The Id of the owning Stream. It must be the same for both the Revision that this Delta targets and the Revision that it will produce.")]
-        public Guid StreamId { get; }
+        public virtual Guid StreamId { get; }
 
         [Description("Represent the differences between two sets of objects.")]
-        public Diff Diff { get; }
+        public virtual Diff Diff { get; }
 
         [Description("Revision Id that this Delta targets.")]
-        public Guid Revision_from { get; }
+        public virtual Guid Revision_from { get; }
 
         [Description("Revision Id that this Delta produces.")]
-        public Guid Revision_to { get; }
+        public virtual Guid Revision_to { get; }
 
         [Description("In UTC ticks.")]
-        public long Timestamp { get; }
+        public virtual long Timestamp { get; }
 
         [Description("Any descriptive string identifying either the Author and/or the software used.")]
-        public string Author { get; }
+        public virtual string Author { get; }
 
-        public string Comment { get; }
+        public virtual string Comment { get; }
 
         /***************************************************/
         /**** Constructor                               ****/
@@ -63,7 +63,7 @@ namespace BH.oM.Diffing
 
         public Delta(Guid streamId, Diff diff, Guid revision_from, Guid revision_to, long timestamp = default(long), string author = null, string comment = null)
         {
-            StreamId = streamId;
+            StreamId = streamId == default(Guid) ? Guid.NewGuid() : streamId;
 
             Diff = diff;
 

--- a/Diffing_oM/Diff.cs
+++ b/Diffing_oM/Diff.cs
@@ -51,9 +51,7 @@ namespace BH.oM.Diffing
         [Description("Objects that are recognised as the same in the first and second set.")]
         public virtual IEnumerable<object> UnchangedObjects { get; }
 
-        [Description("The Key is the modified object hash. The Value is another Dictionary, whose Key is the name of the modified property, while Value.Item1 is the property value in setA, Value.Item2 in setB." +
-            "\nThis dictionary may be exploded by using BH.Engine.Diffing.Query.ListModifiedProperties().")]
-        public virtual Dictionary<string, Dictionary<string, Tuple<object, object>>> ModifiedPropsPerObject { get; }
+        public virtual IEnumerable<ObjectDifferences> ModifiedObjectsDifferences { get; }
 
         [Description("Default diffing settings for this Stream. Hashes of objects contained in this stream will be computed based on these configs.")]
         public virtual DiffingConfig DiffingConfig { get; }
@@ -67,13 +65,13 @@ namespace BH.oM.Diffing
         [Input("removedObjects", "Objects existing exclusively in the 'secondary' set, i.e. the 'old' objects.")]
         [Input("modifiedObjects", "Objects existing in both sets that have some differences in their properties.")]
         [Input("modifiedPropsPerObject", "Dictionary holding the differences in properties of the 'modified' objects. See the corresponding property description for more info.")]
-        public Diff(IEnumerable<object> addedObjects, IEnumerable<object> removedObjects, IEnumerable<object> modifiedObjects, DiffingConfig diffingConfig, Dictionary<string, Dictionary<string, Tuple<object, object>>> modifiedPropsPerObject = null, IEnumerable<object> unchangedObjects = null)
+        public Diff(IEnumerable<object> addedObjects, IEnumerable<object> removedObjects, IEnumerable<object> modifiedObjects, DiffingConfig diffingConfig, IEnumerable<ObjectDifferences> modifiedObjectsDifferences = null, IEnumerable<object> unchangedObjects = null)
         {
             AddedObjects = addedObjects;
             RemovedObjects = removedObjects;
             ModifiedObjects = modifiedObjects;
             DiffingConfig = diffingConfig;
-            ModifiedPropsPerObject = modifiedPropsPerObject;
+            ModifiedObjectsDifferences = modifiedObjectsDifferences;
             UnchangedObjects = unchangedObjects;
         }
 

--- a/Diffing_oM/DiffingConfig.cs
+++ b/Diffing_oM/DiffingConfig.cs
@@ -33,22 +33,17 @@ namespace BH.oM.Diffing
     [Description("General configurations for the Diffing process, including settings for the Hash computation.")]
     public class DiffingConfig : IObject
     {
-        /***************************************************/
+        /***************************************************/ 
         /**** Properties                                ****/
         /***************************************************/
 
         [Description("Settings to determine the uniqueness of an Object.")]
-        public virtual ComparisonConfig ComparisonConfig { get; set; } = new ComparisonConfig();
+        public virtual BaseComparisonConfig ComparisonConfig { get; set; } = new ComparisonConfig();
 
         [Description("Enables the property-level diffing: differences in object properties are stored in the `ModifiedPropsPerObject` dictionary of the Diff object." +
             "\nWARNING: may be slow." +
             "\nFor large object collections, if you are not interested in what properties changed, you can turn this to false to speed up.")]
         public virtual bool EnablePropertyDiffing { get; set; } = true;
-
-        [Description("If EnablePropertyDiffing is true, this sets the maximum number of differences to be determine before stopping." +
-            "\nUseful to limit the run time." +
-            "\nDefaults to 1000.")]
-        public virtual int MaxPropertyDifferences { get; set; } = 1000;
 
         [Description("If enabled, the Diff includes also the objects that did not change (`Unchanged`)." +
             "\nWhen dealing with very large sets, you can keep this on `false` to improve performance: the UnchangedObjects can be derived from the original set, minus the Deleted and Modified objects.")]

--- a/Diffing_oM/ObjectDifferences.cs
+++ b/Diffing_oM/ObjectDifferences.cs
@@ -20,15 +20,28 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using BH.oM.Reflection.Attributes;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace BH.oM.Base
+namespace BH.oM.Diffing
 {
-    [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
-    public class ComparisonConfig : BaseComparisonConfig
+    [Description("Represents all the differences found between a Previous and Following version of an object.")]
+    public class ObjectDifferences : IObject
     {
+        [Description("Older version of the object (created or modified before `FollowingObject`).")]
+        public virtual object PastObject { get; set; }
+
+        [Description("Newer version of the object (created or modified after `PastObject`).")]
+        public virtual object FollowingObject { get; set; }
+
+        [Description("Represents all of the property differences found between the `past` and `following` versions of the object (under a given ComparisonConfig).")]
+        public virtual List<PropertyDifference> Differences { get; set; } = new List<PropertyDifference>();
     }
 }
 

--- a/Diffing_oM/PropertyDifference.cs
+++ b/Diffing_oM/PropertyDifference.cs
@@ -20,15 +20,31 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using BH.oM.Reflection.Attributes;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace BH.oM.Base
+namespace BH.oM.Diffing
 {
-    [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
-    public class ComparisonConfig : BaseComparisonConfig
+    [Description("Represents a difference found between a Previous and Following version of an object.")]
+    public class PropertyDifference : IObject
     {
+        [Description("The human-friendly name associated with this property difference. This may differ from the actual property name: see `FullName`.")]
+        public virtual string DisplayName { get; set; }
+
+        [Description("The older value of this property (associated with the past version of the object).")]
+        public virtual object PastValue { get; set; }
+
+        [Description("The newer value of this property (associated with the following version of the object).")]
+        public virtual object FollowingValue { get; set; }
+
+        [Description("Actual Full Name of the object's property whose value is different.")]
+        public virtual string FullName { get; set; }
     }
 }
 

--- a/Diffing_oM/Versioning_50.json
+++ b/Diffing_oM/Versioning_50.json
@@ -3,5 +3,6 @@
         "BH.oM.Diffing.DiffingType": "The enum object DiffingType does not exists anymore, as its functionality was removed from the BH.Engine.Diffing.IDiffing method because that automation was deemed redundant and not reliable. To use specific Diffing methodologies, just call the specific Diffing method."
     },
     "MessageForNoUpgrade": {
+        "BH.oM.Diffing.Diff": "The Diff object has been redefined in such a way that automatic versioning is not possible. The change happened on the `ModifiedPropertiesPerObject` property that is now renamed to `ModifiedObjectsDifferences`. That used to be a Dictionary<string, Dictionary<string, Tuple<object,object>>, where: the outer Dictionary key was the modified object hash, whilst the value was a Dictionary of the modified properties; and the inner Dictionary key was the modified property name, whilst the value was a Tuple with the following value and the old value. This has completely been reworked with structured classes. Please re-compute the Diff using one of the available diffing methods."
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/BHoM/issues/1308
Closes #1318 

**Note**: this replaces https://github.com/BHoM/BHoM/pull/1306 due to rebase conflicts.

<!-- Add short description of what has been fixed -->
#### Simplification of the `Diff` object
The new Diff object has a simplified structure for the `ModifiedPropertiesPerObject` property (no more `Dictionary<Dictionary<Tuple<object, object>>>`). 

#### 1) `ComparisonInclusion` object

Added a `ComparisonInclusion` object that stores the result of the method of the same name, which can be implemented in specific Toolkits. This latter is called automatically by Diffing/Hash methods to determine if/how to include certain property differences. See https://github.com/BHoM/BHoM_Engine/pull/2699.

#### 2) `ComparisonConfig` class
Created a `ComparisonConfig` abstract class to allow Toolkits to implement more specific configurations. A default ComparisonConfig implementation is provided too.

#### 3) Removal of the `ComparisonFunctions` class
This also removes the object `ComparisonFunctions` related to the previous temporary solution that used delegates to resolve the `PropertyToInclude` diffing feature. This has been replaced by the `ComparisonInclusion()` method invoked through a `TryRunExtesionsMethod()` call. See https://github.com/BHoM/BHoM_Engine/pull/2699.

#### 4) New `PropertyNumericTolerance` class and related ComparisonConfig additions
This class allows to set custom tolerances per specific property names in the `ComparisonConfig`. 

#### Conclusion
This set of PRs is the final wave of big changes done to the Diffing and related objects/functions (e.g. Hash) in this Beta, and I expect that it will more or less settle here.
Once these are approved (i.e. we like the solution), I will document the entire structure of the code, add a proper wiki, diagrams and many tutorial resources.

### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/BHoM_Engine/pull/2699

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added a `ComparisonInclusion` object that stores the result of the method of the same name, which can be implemented in specific Toolkits. This latter is called automatically by Diffing/Hash methods to determine if/how to include certain property differences. See https://github.com/BHoM/BHoM_Engine/pull/2699
- Created a `ComparisonConfig` abstract class to allow Toolkits to implement more specific configurations. A default ComparisonConfig implementation is provided too.
- Removed the previous solution that used ComparisonFunctions delegates.
- Added `ComparisonConfig` settings related to Numeric Tolerance and Significant Figures.
