### PR TITLE
Base_oM: `ComparisonConfig` properties description, naming and order revised for compliance

### DIFF
--- a/BHoM/BaseComparisonConfig.cs
+++ b/BHoM/BaseComparisonConfig.cs
@@ -29,35 +29,38 @@ namespace BH.oM.Base
     [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
     public abstract class BaseComparisonConfig : IObject
     {
-        [Description("Names of properties you want to disregard in defining the uniqueness of an object. `BHoM_Guid` is always added by default. Supports * wildcard (see examples below)."
-            + "\nExamples of valid values: `BHoM_Guid`, `StartNode`, `Bar.StartNode.Point.X`, `Bar.*.Point.Y`")]
+        [Description("Names of properties you want to disregard in defining the uniqueness of an object. You can specify the property name or the Full Name. Supports * wildcard."
+            + "\nExamples of valid values: `BHoM_Guid`, `StartNode`, `Bar.StartNode.Position.X`, `Bar.*.Position.Y`. See the wiki for more details.")]
         public virtual List<string> PropertyExceptions { get; set; } = new List<string>() { };
 
-        [Description("Any corresponding namespace is ignored. E.g. `BH.oM.Structure`.")]
-        public virtual List<string> NamespaceExceptions { get; set; } = new List<string>();
+        [Description("If one or more entries are specified here, only objects/properties that match them will be considered in the hash." +
+           "\nE.g. Given input objects BH.oM.Structure.Elements.Bar, specifying `StartNode` will only check that property of the Bar." +
+           "\nLike for PropertyExceptions, you can specify the property name or the Full Name. Supports * wildcard." +
+           "\nNote that using this will incur in a general slowdown because it is computationally heavy. See the wiki for more details.")]
+        public virtual List<string> PropertiesToConsider { get; set; } = new List<string>();
 
-        [Description("Any corresponding type is ignored. E.g. `typeof(Guid)`.")]
-        public virtual List<Type> TypeExceptions { get; set; } = new List<Type>();
+        [Description("Keys of the BHoMObjects' CustomData dictionary that should be ignored." +
+            "\nBy default it includes `RenderMesh`. " +
+            "\nThis does not support wildcard usage. See the wiki for more details.")]
+        public virtual List<string> CustomdataKeysExceptions { get; set; } = new List<string>() { "RenderMesh" };
 
         [Description("Keys of the BHoMObjects' CustomData dictionary that should be included in the comparison." +
             "\nAdding keys to this List will exclude any key that is not in this List." +
             "\nI.e. for every object, if it has CustomData keys present in this List, we then exclude any other CustomData key found in it.")]
         public virtual List<string> CustomdataKeysToConsider { get; set; } = new List<string>() { };
 
-        [Description("Keys of the BHoMObjects' CustomData dictionary that should be ignored.\nBy default it includes `RenderMesh`.")]
-        public virtual List<string> CustomdataKeysExceptions { get; set; } = new List<string>() { "RenderMesh" };
+        [Description("Any corresponding type is ignored. E.g. `typeof(Guid)`.")]
+        public virtual List<Type> TypeExceptions { get; set; } = new List<Type>();
 
-        [Description("If any name is specified here, only properties corresponding to that name will be considered in the hash." +
-           "\nE.g. For BH.oM.Structure.Elements.Bar, specifying `StartNode` will only check if that property is different." +
-           "\nYou can List specify sub-properties or partial paths, e.g. `StartNode.Name` or `*.Name`.")]
-        public virtual List<string> PropertiesToConsider { get; set; } = new List<string>();
+        [Description("Any corresponding namespace is ignored. E.g. `BH.oM.Structure`. Does not support wildcard. See the wiki for more details.")]
+        public virtual List<string> NamespaceExceptions { get; set; } = new List<string>();
 
         [Description("If any property is nested into the object over that level, it is ignored. Useful to limit the runtime." +
-            "Defaults to unlimited.")]
+            "\nDefaults to unlimited.")]
         public virtual int MaxNesting { get; set; } = int.MaxValue;
 
         [Description("Sets the maximum number of property differences to be determined before stopping. Useful to limit the runtime." +
-            "Defaults to unlimited.")]
+            "\nDefaults to unlimited.")]
         public virtual int MaxPropertyDifferences { get; set; } = int.MaxValue;
 
         [Description("Numeric tolerance for property values, applied to all numerical properties. Defaults to double.MinValue: no rounding applied." +
@@ -66,24 +69,23 @@ namespace BH.oM.Base
             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
         public virtual double NumericTolerance { get; set; } = double.MinValue;
 
-        [Description("Number of significant figures allowed for numerical data." +
-            "\nDefaults to `int.MaxValue`: no approximation applied." +
-            "\nYou can override on a per-property basis by using `PropertySignificantDigits`." +
-            "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual int SignificantFigures { get; set; } = int.MaxValue;
-
         [Description("Tolerance used for individual properties. When computing Hash or the property Diffing, if the analysed property name is found in this collection, the corresponding tolerance is applied." +
             "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
             "\nIf a match is found, this take precedence over the global `NumericTolerance`." +
             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
         public virtual HashSet<NamedNumericTolerance> PropertyNumericTolerances { get; set; } = new HashSet<NamedNumericTolerance>();
 
+        [Description("Number of significant figures allowed for numerical data." +
+            "\nDefaults to `int.MaxValue`: no approximation applied." +
+            "\nYou can override on a per-property basis by using `PropertySignificantDigits`." +
+            "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
+        public virtual int SignificantFigures { get; set; } = int.MaxValue;
+
         [Description("Number of significant figures allowed for numerical data on a per-property base. " +
              "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
              "\nIf a match is found, this take precedence over the global `SignificantFigures`." +
              "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
         public virtual HashSet<NamedSignificantFigures> PropertySignificantFigures { get; set; } = new HashSet<NamedSignificantFigures>();
-
     }
 }
 

--- a/BHoM/BaseComparisonConfig.cs
+++ b/BHoM/BaseComparisonConfig.cs
@@ -39,8 +39,10 @@ namespace BH.oM.Base
         [Description("Any corresponding type is ignored. E.g. `typeof(Guid)`.")]
         public virtual List<Type> TypeExceptions { get; set; } = new List<Type>();
 
-        [Description("Keys of the BHoMObjects' CustomData dictionary that should be exclusively included. Adding keys to this List will exclude any key that is not in this List. I.e. for every object, if it has CustomData keys present in this List, we then exclude any other CustomData key found in it.")]
-        public virtual List<string> CustomdataKeysToInclude { get; set; } = new List<string>() { };
+        [Description("Keys of the BHoMObjects' CustomData dictionary that should be included in the comparison." +
+            "\nAdding keys to this List will exclude any key that is not in this List." +
+            "\nI.e. for every object, if it has CustomData keys present in this List, we then exclude any other CustomData key found in it.")]
+        public virtual List<string> CustomdataKeysToConsider { get; set; } = new List<string>() { };
 
         [Description("Keys of the BHoMObjects' CustomData dictionary that should be ignored.\nBy default it includes `RenderMesh`.")]
         public virtual List<string> CustomdataKeysExceptions { get; set; } = new List<string>() { "RenderMesh" };

--- a/BHoM/Versioning_50.json
+++ b/BHoM/Versioning_50.json
@@ -1,5 +1,11 @@
 ﻿{
     "Property": {
+        "ToNew": {
+            "BH.oM.Base.BaseComparisonConfig.CustomdataKeysToInclude": "BH.oM.Base.BaseComparisonConfig.CustomdataKeysToConsider"
+        },
+        "ToOld": {
+            "BH.oM.Base.BaseComparisonConfig.CustomdataKeysToConsider": "BH.oM.Base.BaseComparisonConfig.CustomdataKeysToInclude"
+        }
     },
     "MessageForDeleted": {
         "BH.oM.Base.ComparisonFunctions": "This object's functionality has been replaced by the ComparisonInclusion() extension method (to be implemented in specific Toolkits that need it; see e.g. Revit) and object."


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1331
Closes #1332

<!-- Add short description of what has been fixed -->
See the changelog for details.

### Test files
<!-- Link to test files to validate the proposed changes -->

Make sure you recompile Versioning after compiling this branch.

Open the following script, that was created before this change:
https://burohappold.sharepoint.com/:f:/s/BHoM/EjfEz1RSi3pEpKpJacZnlMQBXBHsA5f5C8c-eht02C2FlQ?e=wL4dzw

all the wires should be connected and versioning should have renamed the property called `CustomDataKeysToInclude` to `CustomDataKeysToConsider`.

Functionality itself is not affected, so testing is not needed, but it can be tested with:
https://burohappold.sharepoint.com/:f:/s/BHoM/ElkWAuBU0CpNhyNhwF96LlEBqkxJgHX3AhBOGlnA4bBwag?e=Kr2FMc



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Renamed `CustomDataKeysToInclude` to `CustomDataKeysToConsider`
- Changed the ordering of the properties in `ComparisonConfig` for ease of use
- Corrected/improved some property descriptions in `ComparisonConfig`