### PR TITLE
Analytical_oM: IResultCollection generic update

### DIFF
--- a/Analytical_oM/Results/IMeshResult.cs
+++ b/Analytical_oM/Results/IMeshResult.cs
@@ -30,7 +30,7 @@ using System.ComponentModel;
 namespace BH.oM.Analytical.Results
 {
     [Description("Base interface for any Mesh result class which is a collection of discrete MeshElementResults.")]
-    public interface IMeshResult<T> : IObjectIdResult, IResultCollection<T> where T : IMeshElementResult
+    public interface IMeshResult<out T> : IObjectIdResult, IResultCollection<T> where T : IMeshElementResult
     {
 
     }

--- a/Analytical_oM/Results/IResultCollection.cs
+++ b/Analytical_oM/Results/IResultCollection.cs
@@ -27,17 +27,6 @@ using System.ComponentModel;
 
 namespace BH.oM.Analytical.Results
 {
-
-    /***************************************************/
-
-    [Description("Non-generic base interface for result collections. The IResultCollection facilitates simpler filtering in the Engine. Classes are generally recommended to implement the IResultCollection<T> interface.")]
-    public interface IResultCollection : IObject, IImmutable, IResult
-    {
-
-    }
-
-    /***************************************************/
-
     [Description("Base interface for results classes that are a collection of individual results, for example IMeshResults.")]
     public interface IResultCollection<out T> : IResult, IImmutable where T : IResult
     {
@@ -46,6 +35,8 @@ namespace BH.oM.Analytical.Results
         /***************************************************/
 
         IReadOnlyList<T> Results { get; }
+
+        /***************************************************/
     }
 }
 

--- a/Analytical_oM/Results/IResultCollection.cs
+++ b/Analytical_oM/Results/IResultCollection.cs
@@ -22,7 +22,7 @@
 
 using BH.oM.Base;
 using System;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace BH.oM.Analytical.Results
@@ -39,17 +39,14 @@ namespace BH.oM.Analytical.Results
     /***************************************************/
 
     [Description("Base interface for results classes that are a collection of individual results, for example IMeshResults.")]
-    public interface IResultCollection<T> : IResultCollection where T : IResult
+    public interface IResultCollection<out T> : IResult, IImmutable where T : IResult
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        ReadOnlyCollection<T> Results { get; }
-
-        /***************************************************/
+        IReadOnlyList<T> Results { get; }
     }
 }
-
 
 

--- a/Environment_oM/Results/Mesh/MeshResult.cs
+++ b/Environment_oM/Results/Mesh/MeshResult.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using BH.oM.Base;
 using System.Collections.ObjectModel;
 using System;
+using System.Linq;
 
 namespace BH.oM.Environment.Results.Mesh
 {
@@ -53,12 +54,12 @@ namespace BH.oM.Environment.Results.Mesh
         /**** Constructors                              ****/
         /***************************************************/
 
-        public MeshResult(IComparable objectId, IComparable resultCase, double timeStep, ReadOnlyCollection<MeshElementResult> results)
+        public MeshResult(IComparable objectId, IComparable resultCase, double timeStep, IEnumerable<MeshElementResult> results)
         {
             ObjectId = objectId;
             ResultCase = resultCase;
             TimeStep = timeStep;
-            Results = results;
+            Results = results == null ? null : new ReadOnlyCollection<MeshElementResult>(results.ToList());
         }
 
         /***************************************************/

--- a/Environment_oM/Results/Mesh/MeshResult.cs
+++ b/Environment_oM/Results/Mesh/MeshResult.cs
@@ -47,7 +47,7 @@ namespace BH.oM.Environment.Results.Mesh
         public virtual double TimeStep { get; } = 0.0;
 
         [Description("A collection of the discrete mesh element results per node")]
-        public virtual ReadOnlyCollection<MeshElementResult> Results { get; }
+        public virtual IReadOnlyList<MeshElementResult> Results { get; }
 
         /***************************************************/
         /**** Constructors                              ****/

--- a/LifeCycleAssessment_oM/Results/LifeCycleAssessmentResult.cs
+++ b/LifeCycleAssessment_oM/Results/LifeCycleAssessmentResult.cs
@@ -26,6 +26,7 @@ using BH.oM.Geometry;
 using System.ComponentModel;
 using BH.oM.Base;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace BH.oM.LifeCycleAssessment.Results
@@ -50,7 +51,7 @@ namespace BH.oM.LifeCycleAssessment.Results
         public virtual LifeCycleAssessmentScope LifeCycleAssessmentScope { get; }
 
         [Description("A collection of the per element LifeCycleAssessment results")]
-        public virtual ReadOnlyCollection<LifeCycleAssessmentElementResult> Results { get; }
+        public virtual IReadOnlyList<LifeCycleAssessmentElementResult> Results { get; }
 
         [Description("The total quantity of the specified EPD Field for all objects in the Project within the LCA Scope.")]
         public virtual double TotalQuantity { get; }

--- a/LifeCycleAssessment_oM/Results/LifeCycleAssessmentResult.cs
+++ b/LifeCycleAssessment_oM/Results/LifeCycleAssessmentResult.cs
@@ -28,6 +28,7 @@ using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace BH.oM.LifeCycleAssessment.Results
 {
@@ -61,13 +62,13 @@ namespace BH.oM.LifeCycleAssessment.Results
         /**** Constructors                              ****/
         /***************************************************/
 
-        public LifeCycleAssessmentResult(IComparable objectId, IComparable resultCase, double timeStep, LifeCycleAssessmentScope lifeCycleAssessmentScope, ReadOnlyCollection<LifeCycleAssessmentElementResult> results, double totalQuantity)
+        public LifeCycleAssessmentResult(IComparable objectId, IComparable resultCase, double timeStep, LifeCycleAssessmentScope lifeCycleAssessmentScope, IEnumerable<LifeCycleAssessmentElementResult> results, double totalQuantity)
         {
             ObjectId = objectId;
             ResultCase = resultCase;
             TimeStep = timeStep;
             LifeCycleAssessmentScope = lifeCycleAssessmentScope;
-            Results = results;
+            Results = results == null ? null : new ReadOnlyCollection<LifeCycleAssessmentElementResult>(results.ToList());
             TotalQuantity = totalQuantity;
         }
 

--- a/Lighting_oM/Results/Mesh/MeshResult.cs
+++ b/Lighting_oM/Results/Mesh/MeshResult.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using BH.oM.Base;
 using System.Collections.ObjectModel;
 using System;
+using System.Linq;
 
 namespace BH.oM.Lighting.Results.Mesh
 {
@@ -53,12 +54,12 @@ namespace BH.oM.Lighting.Results.Mesh
         /**** Constructors                              ****/
         /***************************************************/
 
-        public MeshResult(IComparable objectId, IComparable resultCase, double timeStep, ReadOnlyCollection<MeshElementResult> results)
+        public MeshResult(IComparable objectId, IComparable resultCase, double timeStep, IEnumerable<MeshElementResult> results)
         {
             ObjectId = objectId;
             ResultCase = resultCase;
             TimeStep = timeStep;
-            Results = results;
+            Results = results == null ? null : new ReadOnlyCollection<MeshElementResult>(results.ToList());
         }
 
         /***************************************************/

--- a/Lighting_oM/Results/Mesh/MeshResult.cs
+++ b/Lighting_oM/Results/Mesh/MeshResult.cs
@@ -47,7 +47,7 @@ namespace BH.oM.Lighting.Results.Mesh
         public virtual double TimeStep { get; } = 0.0;
 
         [Description("A collection of the discrete mesh element results per node")]
-        public virtual ReadOnlyCollection<MeshElementResult> Results { get; }
+        public virtual IReadOnlyList<MeshElementResult> Results { get; }
 
         /***************************************************/
         /**** Constructors                              ****/

--- a/Structure_oM/Results/Mesh/MeshResult.cs
+++ b/Structure_oM/Results/Mesh/MeshResult.cs
@@ -58,7 +58,7 @@ namespace BH.oM.Structure.Results
         public virtual MeshResultSmoothingType Smoothing { get; }
 
         [Description("A collection of the discrete mesh element results per node and/or face.")]
-        public virtual ReadOnlyCollection<MeshElementResult> Results { get; }
+        public virtual IReadOnlyList<MeshElementResult> Results { get; }
 
         /***************************************************/
         /**** Constructors                              ****/

--- a/Test_oM/Results/InputOutputComparison.cs
+++ b/Test_oM/Results/InputOutputComparison.cs
@@ -50,7 +50,7 @@ namespace BH.oM.Test.Results
         public virtual InputOutputComparisonType ResultType { get; }
 
         [Description("Any differences between the input object and the returned object.")]
-        public virtual ReadOnlyCollection<InputOutputDifference> Results { get; }
+        public virtual IReadOnlyList<InputOutputDifference> Results { get; }
 
         [Description("Time of the results creation as OADate")]
         public virtual double TimeStep { get; }

--- a/Test_oM/Results/InputOutputComparison.cs
+++ b/Test_oM/Results/InputOutputComparison.cs
@@ -32,7 +32,7 @@ using System.Collections.ObjectModel;
 
 namespace BH.oM.Test.Results
 {
-    public class InputOutputComparison : IResultCollection<InputOutputDifference>
+    public class InputOutputComparison : IResultCollection<InputOutputDifference>, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1359 

<!-- Add short description of what has been fixed -->

Changing property type from `ReadOnlyCollection` to `IReadOnlyList` which allows for the use of the covariant `out` keyword on the interface. This means that an engine method written to accept for example an `IResultCollection<IResult>` should accept an `IResultCollection<BarForce>` similar to the way `IEnumerable<object>` etc works.

Also will give similar benefits to the `IMeshResult<T>` interface which also will be able to use the out keyword.

With this change the non-generic class can safely be removed as the only reason for this interface was to help with filtering.



### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

Some toolkits will need slight alignment before this is merged. Raising PR for @alelom to have a first look.