### PR TITLE
Facade_oM: Extrusion Bounding Box Fragment

### DIFF
--- a/Facade_oM/Fragments/BoundingBox.cs
+++ b/Facade_oM/Fragments/BoundingBox.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using System.ComponentModel;
+using BH.oM.Geometry;
+
+namespace BH.oM.Facade.Fragments
+{
+    [Description("Fragment containing a curve enclosing the portion of a mullion cross section that will be extruded by Facade_Engine method that changes mullion profile depth.")]
+    public class BoundingBox : IFragment
+    {
+        [Description("ICurve representing the mullion bounding box.")]
+        public virtual ICurve BoundingBoxCurve { get; set; } = null; //Should this be ICurve or IProfile? Mullion cross section is IProfile
+}
+}

--- a/Facade_oM/Fragments/FrameExtensionBox.cs
+++ b/Facade_oM/Fragments/FrameExtensionBox.cs
@@ -32,9 +32,9 @@ using BH.oM.Geometry;
 namespace BH.oM.Facade.Fragments
 {
     [Description("Fragment containing a curve enclosing the portion of a mullion cross section that will be extruded by Facade_Engine method that changes mullion profile depth.")]
-    public class BoundingBox : IFragment
+    public class FrameExtensionBox : IFragment
     {
         [Description("ICurve representing the mullion bounding box.")]
-        public virtual ICurve BoundingBoxCurve { get; set; } = null; //Should this be ICurve or IProfile? Mullion cross section is IProfile
+        public virtual ICurve BoundingBoxCurve { get; set; } = null;
 }
 }

--- a/Facade_oM/Fragments/GlazingLocation.cs
+++ b/Facade_oM/Fragments/GlazingLocation.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+
+using System.ComponentModel;
+
+namespace BH.oM.Facade.Fragments
+{
+    [Description("Fragment containing the offset distance from the section property origin to the edge of glazing.")]
+    public class GlazingLocation : IFragment
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Offset distance from the section property origin to the edge of glazing")]
+        public virtual double GlazingOffsetDistance { get; set; } = 0;
+
+        /***************************************************/
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1233 

<!-- Add short description of what has been fixed -->
Adds 2 new fragments -
1. FrameExtensionBox is a curve that encloses the portion of a mullion cross section to be extruded for mullion depth methods.
2. GlazingLocation is a double that gives the distance between the cross section origin and the edge of glazing 


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Facade_oM/%231233-ExtrusionBoundingBox?csf=1&web=1&e=bRL6iB