### PR TITLE
Analytical_oM: Change ResultFilter HashSets to string

### DIFF
--- a/Analytical_oM/Results/ResultFilter.cs
+++ b/Analytical_oM/Results/ResultFilter.cs
@@ -36,16 +36,16 @@ namespace BH.oM.Analytical.Results
         /***************************************************/
 
         [Description("If ResultCaseFilters contains items, only results of type ICasedResult will be returned that has a ResultCase matching any items in the ResultCaseFilters.")]
-        public virtual HashSet<IComparable> ResultCaseFilters { get; set; } = new HashSet<IComparable>();
+        public virtual HashSet<string> ResultCaseFilters { get; set; } = new HashSet<string>();
 
         [Description("If ObjectIDFilters contains items, only results of type IObjectIdResult will be returned that has a ObjectId matching any items in the ObjectIDFilters.")]
-        public virtual HashSet<IComparable> ObjectIDFilters { get; set; } = new HashSet<IComparable>();
+        public virtual HashSet<string> ObjectIDFilters { get; set; } = new HashSet<string>();
 
         [Description("If NodeIDFilters contains items, only results of type IMeshElementResult will be returned that has a NodeId matching any items in the NodeIDFilters.")]
-        public virtual HashSet<IComparable> NodeIDFilters { get; set; } = new HashSet<IComparable>();
+        public virtual HashSet<string> NodeIDFilters { get; set; } = new HashSet<string>();
 
         [Description("If MeshFaceIDFilters contains items, only results of type IMeshElementResult will be returned that has a MeshFaceId matching any items in the MeshFaceIDFilters.")]
-        public virtual HashSet<IComparable> MeshFaceIDFilters { get; set; } = new HashSet<IComparable>();
+        public virtual HashSet<string> MeshFaceIDFilters { get; set; } = new HashSet<string>();
 
         [Description("If TimeStepFilters contains items, only results of type ITimeStepResult will be returned that has a TimeStep matching any items in the TimeStepFilters.")]
         public virtual HashSet<double> TimeStepFilters { get; set; } = new HashSet<double>();
@@ -59,7 +59,7 @@ namespace BH.oM.Analytical.Results
         {
             if (string.IsNullOrEmpty(resultFilter))
                 return null;
-            return new ResultFilter { ResultCaseFilters = new HashSet<IComparable> { resultFilter } };
+            return new ResultFilter { ResultCaseFilters = new HashSet<string> { resultFilter } };
         }
 
         /***************************************************/
@@ -67,7 +67,7 @@ namespace BH.oM.Analytical.Results
         [Description("Casting method to allow for simpler usage with the common case of filtering by a singe ResultCase.")]
         public static explicit operator ResultFilter(int resultFilter)
         {
-            return new ResultFilter { ResultCaseFilters = new HashSet<IComparable> { resultFilter } };
+            return new ResultFilter { ResultCaseFilters = new HashSet<string> { resultFilter.ToString() } };
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1375 

<!-- Add short description of what has been fixed -->

Changing to hashsets of string rather than hashsets of IComparable for result filtering to allow for better usability from the UI.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Analytical_oM/%231376-ChangeResultFiltersToStringHashSets?csf=1&web=1&e=ZxWpLB

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->