### PR TITLE
Graphics_oM: Add graphics render texture

### DIFF
--- a/Graphics_oM/Render/RenderGeometry.cs
+++ b/Graphics_oM/Render/RenderGeometry.cs
@@ -42,8 +42,8 @@ namespace BH.oM.Graphics
         [Description("Colour used to render the edges of the Geometry. If texture is not set, this colour will also be used to render any meshes and surfaces of the Geometry. Default is BHoM Coral with a subtle transparency (Color.FromArgb(80, 255, 41, 105)).")]
         public virtual Color Colour { get; set; } = Color.FromArgb(80, 255, 41, 105);
 
-        [Description("Texture to be used for mesh and surface geometry. If null, the colour will be used for mesh and surface rendering instead.")]
-        public virtual Texture Texture { get; set; } = null;
+        [Description("Optional texture or colour to be used for mesh and surface geometry. If null, the colour will be used for mesh and surface rendering instead.")]
+        public virtual Texture SurfaceColour { get; set; } = null;
 
         [Description("The thickness of the curve. Should be a value greater or equal to 1.")]
         public virtual int EdgeThickness { get; set; } = 1;

--- a/Graphics_oM/Render/RenderGeometry.cs
+++ b/Graphics_oM/Render/RenderGeometry.cs
@@ -39,8 +39,14 @@ namespace BH.oM.Graphics
         [Description("A geometry (or many geometry objects collected into a single `CompositeGeometry` object).")]
         public virtual IGeometry Geometry { get; set; }
 
-        [Description("Colour used to render the Geometry. Default is BHoM Coral with a subtle transparency (Color.FromArgb(80, 255, 41, 105)).")]
+        [Description("Colour used to render the edges of the Geometry. If texture is not set, this colour will also be used to render any meshes and surfaces of the Geometry. Default is BHoM Coral with a subtle transparency (Color.FromArgb(80, 255, 41, 105)).")]
         public virtual Color Colour { get; set; } = Color.FromArgb(80, 255, 41, 105);
+
+        [Description("Texture to be used for mesh and surface geometry. If null, the colour will be used for mesh and surface rendering instead.")]
+        public virtual Texture Texture { get; set; } = null;
+
+        [Description("The thickness of the curve. Should be a value greater or equal to 1.")]
+        public virtual int EdgeThickness { get; set; } = 1;
 
         /***************************************************/
 

--- a/Graphics_oM/Render/Texture.cs
+++ b/Graphics_oM/Render/Texture.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+
+namespace BH.oM.Graphics
+{
+    [Description("Texture material for rendering of geometry.")]
+    public class Texture : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Name of the Texture")]
+        public override string Name { get; set; } = "";
+
+        [Description("Diffuse color is the most instinctive meaning of the color of an object. It is that essential color that the object reveals under pure white light. It is perceived as the color of the object itself rather than a reflection of the light. Alpha channel is generally ignored. Default is BHoM Coral (Color.FromArgb(255, 255, 41, 105)).")]
+        public virtual Color Diffuse { get; set; } = Color.FromArgb(255, 255, 41, 105);
+
+        [Description("This is the self-illumination color an object has. Alpha channel is generally ignored. Default is a darker BHoM Coral (Color.FromArgb(255, 77, 12, 32))")]
+        public virtual Color Emission { get; set; } = Color.FromArgb(255, 77, 12, 32);
+
+        [Description("Ambient color is the color of an object where it is in shadow. This color is what the object reflects when illuminated by ambient light rather than direct light. Alpha channel is generally ignored. Default is Gray.")]
+        public virtual Color Ambient { get; set; } = Color.Gray;
+
+        [Description("Specular color is the color of the light of a specular reflection (specular reflection is the type of reflection that is characteristic of light reflected from a shiny surface). Alpha channel is generally ignored. Default is White.")]
+        public virtual Color Specular { get; set; } = Color.White;
+
+        [Description("Level of transparency of the material. Should be a value between 0 and 1, where 0.0 is opaque and 1.0 is transparent. Defaults to fully opaque.")]
+        public virtual double Transparency { get; set; } = 0.0;
+
+        [Description("Shine factor of the material. Should be a value between 0 and 1, where 0 is no shine and 1 is full shine.")]
+        public virtual double Shine { get; set; } = 0.5;
+
+        [FilePath]
+        [Description("Optional file path to a image file to use as bitmap texture for the material.")]
+        public virtual string BitmapTexture { get; set; } = "";
+
+        /***************************************************/
+        /**** Explicit Casting                          ****/
+        /***************************************************/
+
+        [Description("Converts a colour to a texture.")]
+        public static explicit operator Texture(Color diffuseColour)
+        {
+            return new Texture
+            {
+                Diffuse = diffuseColour,
+                Emission = Color.FromArgb(diffuseColour.A, (int)Math.Round(diffuseColour.R * 0.3), (int)Math.Round(diffuseColour.G * 0.3), (int)Math.Round(diffuseColour.B * 0.3)),
+                Specular = Color.White,
+                Ambient = Color.Gray,
+                Transparency = (double)(255 - diffuseColour.A) / 255.0,
+                Shine = 0.5
+            };
+        }
+
+        /***************************************************/
+
+    }
+}
+
+

--- a/Graphics_oM/Render/Texture.cs
+++ b/Graphics_oM/Render/Texture.cs
@@ -40,17 +40,17 @@ namespace BH.oM.Graphics
         [Description("Name of the Texture")]
         public override string Name { get; set; } = "";
 
-        [Description("Diffuse color is the most instinctive meaning of the color of an object. It is that essential color that the object reveals under pure white light. It is perceived as the color of the object itself rather than a reflection of the light. Alpha channel is generally ignored. Default is BHoM Coral (Color.FromArgb(255, 255, 41, 105)).")]
+        [Description("The governing colour of the texture. The colour under direct illumination in white light. Alpha channel is generally ignored. Default is BHoM Coral (Color.FromArgb(255, 255, 41, 105)).")]
         public virtual Color Diffuse { get; set; } = Color.FromArgb(255, 255, 41, 105);
 
-        [Description("This is the self-illumination color an object has. Alpha channel is generally ignored. Default is a darker BHoM Coral (Color.FromArgb(255, 77, 12, 32))")]
-        public virtual Color Emission { get; set; } = Color.FromArgb(255, 77, 12, 32);
-
-        [Description("Ambient color is the color of an object where it is in shadow. This color is what the object reflects when illuminated by ambient light rather than direct light. Alpha channel is generally ignored. Default is Gray.")]
+        [Description("The colour under ambient lighting conditions. Alpha channel is generally ignored. Default is Gray.")]
         public virtual Color Ambient { get; set; } = Color.Gray;
 
-        [Description("Specular color is the color of the light of a specular reflection (specular reflection is the type of reflection that is characteristic of light reflected from a shiny surface). Alpha channel is generally ignored. Default is White.")]
+        [Description("Controls shine and highlights. Alpha channel is generally ignored. Default is White.")]
         public virtual Color Specular { get; set; } = Color.White;
+
+        [Description("Self-illumination colour. Alpha channel is generally ignored. Default is a darker BHoM Coral (Color.FromArgb(255, 77, 12, 32))")]
+        public virtual Color Emission { get; set; } = Color.FromArgb(255, 77, 12, 32);
 
         [Description("Level of transparency of the material. Should be a value between 0 and 1, where 0.0 is opaque and 1.0 is transparent. Defaults to fully opaque.")]
         public virtual double Transparency { get; set; } = 0.0;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #485

<!-- Add short description of what has been fixed -->

Add graphics texture class to handle rendering of surface and meshes. Defaults to BHoM Pink with no bitmap.

Adding a explicit casting from Colour to Texture to allow easier generation from the UI.

General intended logic of the class is that the Colour property always gives the colour of the edges, while the Texture property gives the colour or texture of the mesh/surface faces. If the texture is not set, the display should fall back on using the colour property instead.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Graphics_oM/%231389-AddGraphsicsRenderTexture?csf=1&web=1&e=NxVT3M

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

- Can also add transparency and bumb maps if we like, but kept it simple, only adding main texture in the first push.
- Later PR to handle adding a IMaterialProperty with a texture that can be applied to a physical Material class.