### PR TITLE
Structure_oM: Adding missing rolling shear modulus and distinction between characteristic and average values for all moduli properties

### DIFF
--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -34,66 +34,66 @@ namespace BH.oM.Structure.MaterialFragments
         /**** Properties                                ****/
         /***************************************************/
 
-        [Description("A unique name is required for some structural packages to create and identify the object.")]
+        [Description("Name. A unique name is required for some structural packages to create and identify the object.")]
         public override string Name { get; set; }
 
         [Density]
-        [Description("Characteristic density used to calculate other mechanical properties, not for calculating mass. Called G (specific gravity) in American codes, called p_k in Eurocode")]
+        [Description("Characteristic Density. Used to calculate other mechanical properties, not for calculating mass. Called G (specific gravity) in American codes, p_k in Eurocode")]
         public virtual double DensityCharacteristic { get; set; }
 
         [Density]
-        [Description("Mean density used to calculate mass. Called p_mean in Eurocode")]
+        [Description("Mean Density. Used to calculate mass. Called p_mean in Eurocode")]
         public virtual double DensityMean { get; set; }
 
         [Ratio]
-        [Description("Dynamic damping ratio, expressed as a ratio between actual damping and critical damping. For structures, typically taken as 0.02 (i.e. 2%).")]
+        [Description("Dynamic Damping Ratio, expressed as a ratio between actual damping and critical damping. For structures, typically taken as 0.02 (i.e. 2%).")]
         public virtual double DampingRatio { get; set; }
         
         [YoungsModulus]
-        [Description("Modulus of elasticity of the material. Ratio between stress and strain in all directions. Constructed for FEA purposes from charactersitic values.")]
+        [Description("Modulus Of Elasticity of the material. Ratio between stress and strain in all directions. Constructed for FEA purposes from parallel and perpendicular characteristic values.")]
         public virtual Vector YoungsModulus { get; set; }
         
         [YoungsModulus]
-        [Description("Mean modulus of elasticity of the material parallel to grain. Ratio between stress and strain. Called E_0,mean in Eurocode.")]
+        [Description("Mean Modulus Of Elasticity of the material parallel to grain. Ratio between stress and strain. Called E_0,mean in Eurocode.")]
         public virtual double YoungsModulusMeanParallel { get; set; }
         
         [YoungsModulus]
-        [Description("Mean modulus of elasticity of the material perpendicular to grain. Ratio between stress and strain. Called E_90,mean in Eurocode.")]
+        [Description("Mean Modulus Of Elasticity of the material perpendicular to grain. Ratio between stress and strain. Called E_90,mean in Eurocode.")]
         public virtual double YoungsModulusMeanPerpendicular { get; set; }
         
         [YoungsModulus]
-        [Description("Characteristic modulus of elasticity of the material parallel to grain. Ratio between stress and strain. Called E_0,k in Eurocode.")]
+        [Description("Characteristic Modulus Of Elasticity of the material parallel to grain. Ratio between stress and strain. Called E_0,k in Eurocode.")]
         public virtual double YoungsModulusCharacteristicParallel { get; set; }        
         [YoungsModulus]
-        [Description("Characteristic modulus of elasticity of the material perpendicular to grain. Ratio between stress and strain. Called E_90,k in Eurocode.")]
+        [Description("Characteristic Modulus Of Elasticity of the material perpendicular to grain. Ratio between stress and strain. Called E_90,k in Eurocode.")]
         public virtual double YoungsModulusCharacteristicPerpendicular { get; set; }
 
         [Ratio]
-        [Description("Ratio between axial and transverse strain.")]
+        [Description("Poisson's Ratio. Ratio between axial and transverse strain. Typically take as 0.4, though value varies depending on timber species.")]
         public virtual Vector PoissonsRatio { get; set; }
 
         [ThermalExpansionCoefficient]
-        [Description("The strain induced in the material per unit change of temperature.")]
+        [Description("Thermal Expansion Coefficeint. The strain induced in the material per unit change of temperature. Typically take as 5x10^-6, though value varies depending on timber species.")]
         public virtual Vector ThermalExpansionCoeff { get; set; }
 
         [ShearModulus]
-        [Description("The shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain. Constructed for FEA purposes from characteristic values.")]
+        [Description("Shear Modulus or Modulus of Rigidity. Defined as the ratio between shear stress and shear strain. Constructed for FEA purposes from parallel and perpendicular characteristic values.")]
         public virtual Vector ShearModulus { get; set; }
         
         [ShearModulus]
-        [Description("The characteristic shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain parallel to the grain. Called G_k in Eurocode.")]
+        [Description("Characteristic Shear Modulus or Modulus Of Rigidity. Defined as the ratio between shear stress and shear strain parallel to the grain. Called G_k in Eurocode.")]
         public virtual double ParallelShearModulusCharacteristic { get; set; }
         
         [ShearModulus]
-        [Description("The mean shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain parallel to the grain. Called G_mean in Eurocode.")]
+        [Description("Mean Shear Modulus or Modulus Of Rigidity. Defined as the ratio between shear stress and shear strain parallel to the grain. Called G_mean in Eurocode.")]
         public virtual double ParallelShearModulusMean { get; set; }        
         
         [ShearModulus]
-        [Description("The characteristic rolling shear modulus. Defined as the ratio between shear stress and shear strain perpendicular to the grain. Called G_r,05 in Eurocode.e")]
+        [Description("Characteristic Rolling Shear Modulus. Defined as the ratio between shear stress and shear strain perpendicular to the grain. Called G_r,05 in Eurocode.e")]
         public virtual double RollingShearModulusCharacteristic { get; set; }
         
         [ShearModulus]
-        [Description("The mean rolling shear modulus. Defined as the ratio between rolling shear stress and rolling shear strain perpendicular to the grain. Called G_r,mean in Eurocode.")]
+        [Description("Mean Rolling Shear Modulus. Defined as the ratio between rolling shear stress and rolling shear strain perpendicular to the grain. Called G_r,mean in Eurocode.")]
         public virtual double RollingShearModulusMean { get; set; }
 
         [Stress]
@@ -121,7 +121,7 @@ namespace BH.oM.Structure.MaterialFragments
         public virtual double ShearStrength { get; set; }
         
         [Stress]
-        [Description("Rolling shear strength or F_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Called F_s in American codes, called F_rk in Eurocode.")]
+        [Description("Rolling Shear Strength or F_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Called F_s in American codes, F_rk in Eurocode.")]
         public virtual double RollingShearStrength { get; set; }
 
         /***************************************************/

--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -42,7 +42,7 @@ namespace BH.oM.Structure.MaterialFragments
         public virtual double DensityDesign { get; set; }
 
         [Density]
-        [Description("Average Density used to calculate mass. Called p_mean in Eurocode")]
+        [Description("Average density used to calculate mass. Called p_mean in Eurocode")]
         public virtual double Density { get; set; }
 
         [Ratio]
@@ -106,8 +106,8 @@ namespace BH.oM.Structure.MaterialFragments
         public virtual double ShearStrength { get; set; }
         
         [Stress]
-        [Description("Rolling Shear Strength or F_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Called F_rk in Eurocode.")]
-        public virtual double ShearStrength { get; set; }
+        [Description("Shear Rolling Strength or F_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Called F_s in American codes, called F_rk in Eurocode.")]
+        public virtual double ShearRollingStrength { get; set; }
 
         /***************************************************/
 

--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -38,7 +38,7 @@ namespace BH.oM.Structure.MaterialFragments
         public override string Name { get; set; }
 
         [Density]
-        [Description("Characteristic Density used to calculate other mechanical properties, not for calculating mass. Called p_k in eurocode")]
+        [Description("Characteristic density used to calculate other mechanical properties, not for calculating mass. Called G (specific gravity) in American codes, called p_k in Eurocode")]
         public virtual double DensityDesign { get; set; }
 
         [Density]

--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -34,28 +34,39 @@ namespace BH.oM.Structure.MaterialFragments
         /**** Properties                                ****/
         /***************************************************/
 
-        [Description("A unique Name is required for some structural packages to create and identify the object.")]
+        [Description("A unique name is required for some structural packages to create and identify the object.")]
         public override string Name { get; set; }
 
         [Density]
         [Description("Characteristic density used to calculate other mechanical properties, not for calculating mass. Called G (specific gravity) in American codes, called p_k in Eurocode")]
-        public virtual double DensityDesign { get; set; }
+        public virtual double DensityCharacteristic { get; set; }
 
         [Density]
-        [Description("Average density used to calculate mass. Called p_mean in Eurocode")]
-        public virtual double Density { get; set; }
+        [Description("Mean density used to calculate mass. Called p_mean in Eurocode")]
+        public virtual double DensityMean { get; set; }
 
         [Ratio]
         [Description("Dynamic damping ratio, expressed as a ratio between actual damping and critical damping. For structures, typically taken as 0.02 (i.e. 2%).")]
         public virtual double DampingRatio { get; set; }
         
         [YoungsModulus]
-        [Description("Characteristic Modulus of elasticity of the material. Ratio between axial stress and axial strain. Called E_05 in Eurocode.")]
+        [Description("Modulus of elasticity of the material. Ratio between stress and strain in all directions. Constructed for FEA purposes from charactersitic values.")]
         public virtual Vector YoungsModulus { get; set; }
         
         [YoungsModulus]
-        [Description("Average Modulus of elasticity of the material. Ratio between axial stress and axial strain. Called E_mean in Eurocode.")]
-        public virtual Vector YoungsModulus { get; set; }
+        [Description("Mean modulus of elasticity of the material parallel to grain. Ratio between stress and strain. Called E_0,mean in Eurocode.")]
+        public virtual double YoungsModulusMeanParallel { get; set; }
+        
+        [YoungsModulus]
+        [Description("Mean modulus of elasticity of the material perpendicular to grain. Ratio between stress and strain. Called E_90,mean in Eurocode.")]
+        public virtual double YoungsModulusMeanPerpendicular { get; set; }
+        
+        [YoungsModulus]
+        [Description("Characteristic modulus of elasticity of the material parallel to grain. Ratio between stress and strain. Called E_0,k in Eurocode.")]
+        public virtual double YoungsModulusCharacteristicParallel { get; set; }        
+        [YoungsModulus]
+        [Description("Characteristic modulus of elasticity of the material perpendicular to grain. Ratio between stress and strain. Called E_90,k in Eurocode.")]
+        public virtual double YoungsModulusCharacteristicPerpendicular { get; set; }
 
         [Ratio]
         [Description("Ratio between axial and transverse strain.")]
@@ -66,20 +77,24 @@ namespace BH.oM.Structure.MaterialFragments
         public virtual Vector ThermalExpansionCoeff { get; set; }
 
         [ShearModulus]
-        [Description("The characteristic shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain. Called G_05 in Eurocode.")]
+        [Description("The shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain. Constructed for FEA purposes from characteristic values.")]
         public virtual Vector ShearModulus { get; set; }
         
         [ShearModulus]
-        [Description("The average shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain. Called G_mean in Eurocode.")]
-        public virtual Vector ShearModulus { get; set; }
+        [Description("The characteristic shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain parallel to the grain. Called G_k in Eurocode.")]
+        public virtual double ParallelShearModulusCharacteristic { get; set; }
         
         [ShearModulus]
-        [Description("The characteristic rolling shear modulus. Defined as the ratio between rolling shear stress and rolling shear strain. Called G_r05 in Eurocode.e")]
-        public virtual Vector ShearModulus { get; set; }
+        [Description("The mean shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain parallel to the grain. Called G_mean in Eurocode.")]
+        public virtual double ParallelShearModulusMean { get; set; }        
         
         [ShearModulus]
-        [Description("The average rolling shear modulus. Defined as the ratio between rolling shear stress and rolling shear strain. Called G_rmean in Eurocode.")]
-        public virtual Vector ShearModulus { get; set; }
+        [Description("The characteristic rolling shear modulus. Defined as the ratio between shear stress and shear strain perpendicular to the grain. Called G_r,05 in Eurocode.e")]
+        public virtual double RollingShearModulusCharacteristic { get; set; }
+        
+        [ShearModulus]
+        [Description("The mean rolling shear modulus. Defined as the ratio between rolling shear stress and rolling shear strain perpendicular to the grain. Called G_r,mean in Eurocode.")]
+        public virtual double RollingShearModulusMean { get; set; }
 
         [Stress]
         [Description("Bending Strength. Defined as the tension stress parallel to the grain at failure in bending as calculated from beam equations. Called F_b in American codes, f_mk in Eurocode.")]
@@ -106,8 +121,8 @@ namespace BH.oM.Structure.MaterialFragments
         public virtual double ShearStrength { get; set; }
         
         [Stress]
-        [Description("Shear Rolling Strength or F_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Called F_s in American codes, called F_rk in Eurocode.")]
-        public virtual double ShearRollingStrength { get; set; }
+        [Description("Rolling shear strength or F_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Called F_s in American codes, called F_rk in Eurocode.")]
+        public virtual double RollingShearStrength { get; set; }
 
         /***************************************************/
 

--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -38,19 +38,23 @@ namespace BH.oM.Structure.MaterialFragments
         public override string Name { get; set; }
 
         [Density]
-        [Description("Density used to calculate other mechanical properties, not for calculating mass.")]
+        [Description("Characteristic Density used to calculate other mechanical properties, not for calculating mass. Called p_k in eurocode")]
         public virtual double DensityDesign { get; set; }
 
         [Density]
-        [Description("Density used to calculate mass.")]
+        [Description("Average Density used to calculate mass. Called p_mean in Eurocode")]
         public virtual double Density { get; set; }
 
         [Ratio]
         [Description("Dynamic damping ratio, expressed as a ratio between actual damping and critical damping. For structures, typically taken as 0.02 (i.e. 2%).")]
         public virtual double DampingRatio { get; set; }
-
+        
         [YoungsModulus]
-        [Description("Modulus of elasticity of the material. Ratio between axial stress and axial strain.")]
+        [Description("Characteristic Modulus of elasticity of the material. Ratio between axial stress and axial strain. Called E_05 in Eurocode.")]
+        public virtual Vector YoungsModulus { get; set; }
+        
+        [YoungsModulus]
+        [Description("Average Modulus of elasticity of the material. Ratio between axial stress and axial strain. Called E_mean in Eurocode.")]
         public virtual Vector YoungsModulus { get; set; }
 
         [Ratio]
@@ -62,7 +66,19 @@ namespace BH.oM.Structure.MaterialFragments
         public virtual Vector ThermalExpansionCoeff { get; set; }
 
         [ShearModulus]
-        [Description("The shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain.")]
+        [Description("The characteristic shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain. Called G_05 in Eurocode.")]
+        public virtual Vector ShearModulus { get; set; }
+        
+        [ShearModulus]
+        [Description("The average shear modulus or modulus of rigidity. Defined as the ratio between shear stress and shear strain. Called G_mean in Eurocode.")]
+        public virtual Vector ShearModulus { get; set; }
+        
+        [ShearModulus]
+        [Description("The characteristic rolling shear modulus. Defined as the ratio between rolling shear stress and rolling shear strain. Called G_r05 in Eurocode.e")]
+        public virtual Vector ShearModulus { get; set; }
+        
+        [ShearModulus]
+        [Description("The average rolling shear modulus. Defined as the ratio between rolling shear stress and rolling shear strain. Called G_rmean in Eurocode.")]
         public virtual Vector ShearModulus { get; set; }
 
         [Stress]
@@ -90,7 +106,7 @@ namespace BH.oM.Structure.MaterialFragments
         public virtual double ShearStrength { get; set; }
         
         [Stress]
-        [Description("Rolling Shear Strength or F_v_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Also called f_vk in Eurocode.")]
+        [Description("Rolling Shear Strength or F_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Called F_rk in Eurocode.")]
         public virtual double ShearStrength { get; set; }
 
         /***************************************************/

--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -88,6 +88,10 @@ namespace BH.oM.Structure.MaterialFragments
         [Stress]
         [Description("Shear Strength or F_v. Defined as the shear stress parallel to the grain at failure in net shear, i.e. shear relevant to beam bending. Called F_v in American codes, f_vk in Eurocode.")]
         public virtual double ShearStrength { get; set; }
+        
+        [Stress]
+        [Description("Rolling Shear Strength or F_v_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Also called f_vk in Eurocode.")]
+        public virtual double ShearStrength { get; set; }
 
         /***************************************************/
 

--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -38,90 +38,67 @@ namespace BH.oM.Structure.MaterialFragments
         public override string Name { get; set; }
 
         [Density]
-        [Description("Characteristic Density. Used to calculate other mechanical properties, not for calculating mass. Called G (specific gravity) in American codes, p_k in Eurocode")]
+        [Description("Characteristic Density. Used to calculate other mechanical properties (not mass). Called G (specific gravity) in American codes, p_k in Eurocode")]
         public virtual double DensityCharacteristic { get; set; }
 
         [Density]
         [Description("Mean Density. Used to calculate mass. Called p_mean in Eurocode")]
-        public virtual double DensityMean { get; set; }
+        public virtual double Density { get; set; }
 
         [Ratio]
-        [Description("Dynamic Damping Ratio, expressed as a ratio between actual damping and critical damping. For structures, typically taken as 0.02 (i.e. 2%).")]
+        [Description("Dynamic Damping Ratio. Ratio between actual damping and critical damping.")]
         public virtual double DampingRatio { get; set; }
         
         [YoungsModulus]
-        [Description("Modulus Of Elasticity of the material. Ratio between stress and strain in all directions. Constructed for FEA purposes from parallel and perpendicular characteristic values.")]
+        [Description("Characteristic Modulus Of Elasticity of the material. Ratio between stress and strain in all directions. Vector componets made up of: X - Parallel, E_0,k in Eurocode; Y - Perpendicular, E_90,k in Eurocode; Z - Perpendicular, E_90,k in Eurocode.")]
         public virtual Vector YoungsModulus { get; set; }
-        
+
         [YoungsModulus]
-        [Description("Mean Modulus Of Elasticity of the material parallel to grain. Ratio between stress and strain. Called E_0,mean in Eurocode.")]
-        public virtual double YoungsModulusMeanParallel { get; set; }
-        
-        [YoungsModulus]
-        [Description("Mean Modulus Of Elasticity of the material perpendicular to grain. Ratio between stress and strain. Called E_90,mean in Eurocode.")]
-        public virtual double YoungsModulusMeanPerpendicular { get; set; }
-        
-        [YoungsModulus]
-        [Description("Characteristic Modulus Of Elasticity of the material parallel to grain. Ratio between stress and strain. Called E_0,k in Eurocode.")]
-        public virtual double YoungsModulusCharacteristicParallel { get; set; }        
-        [YoungsModulus]
-        [Description("Characteristic Modulus Of Elasticity of the material perpendicular to grain. Ratio between stress and strain. Called E_90,k in Eurocode.")]
-        public virtual double YoungsModulusCharacteristicPerpendicular { get; set; }
+        [Description("Mean Modulus Of Elasticity of the material. Ratio between stress and strain in all directions. Vector components made up of: X - Parallel, E_0,mean in Eurocode; Y - Perpendicular, E_90,mean in Eurocode; Z - Perpendicular, E_90,mean in Eurocode.")]
+        public virtual Vector YoungsModulusMean { get; set; }
 
         [Ratio]
-        [Description("Poisson's Ratio. Ratio between axial and transverse strain. Typically take as 0.4, though value varies depending on timber species.")]
+        [Description("Poisson's Ratio. Ratio between axial and transverse strain. Typically take as 0.4 in all directions, though value varies depending on timber species. Vector components made up of: X - Parallel; Y - Perpendicular; Z - Perpendicular.")]
         public virtual Vector PoissonsRatio { get; set; }
 
         [ThermalExpansionCoefficient]
-        [Description("Thermal Expansion Coefficeint. The strain induced in the material per unit change of temperature. Typically take as 5x10^-6, though value varies depending on timber species.")]
+        [Description("Thermal Expansion Coefficeint. Strain induced in the material per unit change of temperature. Typically take as 5x10^-6 in all directions, though value varies depending on timber species. Vector components made up of: X - Parallel; Y - Perpendicular; Z - Perpendicular.")]
         public virtual Vector ThermalExpansionCoeff { get; set; }
 
         [ShearModulus]
-        [Description("Shear Modulus or Modulus of Rigidity. Defined as the ratio between shear stress and shear strain. Constructed for FEA purposes from parallel and perpendicular characteristic values.")]
+        [Description("Characterstic Shear Modulus or Modulus of Rigidity. Ratio between shear stress and shear strain. Vector components made up of: X - Parallel, G_k in Eurocode; Y - Parallel, G_k in Eurocode; Z - Perpendicular, G_r,05 in Eurocode.")]
         public virtual Vector ShearModulus { get; set; }
-        
+
         [ShearModulus]
-        [Description("Characteristic Shear Modulus or Modulus Of Rigidity. Defined as the ratio between shear stress and shear strain parallel to the grain. Called G_k in Eurocode.")]
-        public virtual double ParallelShearModulusCharacteristic { get; set; }
-        
-        [ShearModulus]
-        [Description("Mean Shear Modulus or Modulus Of Rigidity. Defined as the ratio between shear stress and shear strain parallel to the grain. Called G_mean in Eurocode.")]
-        public virtual double ParallelShearModulusMean { get; set; }        
-        
-        [ShearModulus]
-        [Description("Characteristic Rolling Shear Modulus. Defined as the ratio between shear stress and shear strain perpendicular to the grain. Called G_r,05 in Eurocode.e")]
-        public virtual double RollingShearModulusCharacteristic { get; set; }
-        
-        [ShearModulus]
-        [Description("Mean Rolling Shear Modulus. Defined as the ratio between rolling shear stress and rolling shear strain perpendicular to the grain. Called G_r,mean in Eurocode.")]
-        public virtual double RollingShearModulusMean { get; set; }
+        [Description("Mean Shear Modulus or Modulus of Rigidity. Ratio between shear stress and shear strain. Vector components made up of: X - Parallel, G_mean in Eurocode; Y - Parallel, G_mean in Eurocode; Z - Perpendicular, G_r,mean in Eurocode.")]
+        public virtual Vector ShearModulusMean { get; set; }
 
         [Stress]
-        [Description("Bending Strength. Defined as the tension stress parallel to the grain at failure in bending as calculated from beam equations. Called F_b in American codes, f_mk in Eurocode.")]
+        [Description("Bending Strength. Tension stress parallel to the grain at failure in bending as calculated from beam equations. Called F_b in American codes, f_mk in Eurocode.")]
         public virtual double BendingStrength { get; set; }
 
         [Stress]
-        [Description("Tension Parallel Strength. Defined as the tension stress parallel to the grain at failure in net tension. Called F_t\u2225 in American codes, f_t0k in Eurocode.")]
+        [Description("Tension Parallel Strength. Tension stress parallel to the grain at failure in net tension. Called F_t\u2225 in American codes, f_t0k in Eurocode.")]
         public virtual double TensionParallelStrength { get; set; }
 
         [Stress]
-        [Description("Tension Perpendicular Strength. Defined as the tension stress perpendicular to the grain at failure in net tension. Called F_t\u27c2 in American codes, f_t90k in Eurocode.")]
+        [Description("Tension Perpendicular Strength. Tension stress perpendicular to the grain at failure in net tension. Called F_t\u27c2 in American codes, f_t90k in Eurocode.")]
         public virtual double TensionPerpendicularStrength { get; set; }
 
         [Stress]
-        [Description("Compression Parallel Strength. Defined as the compression stress parallel to the grain at failure in net compression. Called F_c\u2225 in American codes, f_c0k in Eurocode.")]
+        [Description("Compression Parallel Strength. Compression stress parallel to the grain at failure in net compression. Called F_c\u2225 in American codes, f_c0k in Eurocode.")]
         public virtual double CompressionParallelStrength { get; set; }
 
         [Stress]
-        [Description("Compression Perpendicular Strength. Defined as the compression stress perpendicular to the grain at failure in net compression. Called F_c\u27c2 in American codes, f_c90k in Eurocode.")]
+        [Description("Compression Perpendicular Strength. Compression stress perpendicular to the grain at failure in net compression. Called F_c\u27c2 in American codes, f_c90k in Eurocode.")]
         public virtual double CompressionPerpendicularStrength { get; set; }
 
         [Stress]
-        [Description("Shear Strength or F_v. Defined as the shear stress parallel to the grain at failure in net shear, i.e. shear relevant to beam bending. Called F_v in American codes, f_vk in Eurocode.")]
+        [Description("Shear Strength. Shear stress parallel to the grain at failure in net shear, i.e. shear relevant to beam bending. Called F_v in American codes, f_vk in Eurocode.")]
         public virtual double ShearStrength { get; set; }
         
         [Stress]
-        [Description("Rolling Shear Strength or F_r. Defined as the shear stress perpendicular to the grain at failure in net shear. Called F_s in American codes, F_rk in Eurocode.")]
+        [Description("Rolling Shear Strength. Shear stress perpendicular to the grain at failure in net shear. Called F_s in American codes, F_rk in Eurocode.")]
         public virtual double RollingShearStrength { get; set; }
 
         /***************************************************/

--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -38,11 +38,11 @@ namespace BH.oM.Structure.MaterialFragments
         public override string Name { get; set; }
 
         [Density]
-        [Description("Characteristic Density. Used to calculate other mechanical properties (not mass). Called G (specific gravity) in American codes, p_k in Eurocode")]
+        [Description("Characteristic Density. Used to calculate other mechanical properties (not mass). Called G (specific gravity) in American codes, p_k in Eurocode.")]
         public virtual double DensityCharacteristic { get; set; }
 
         [Density]
-        [Description("Mean Density. Used to calculate mass. Called p_mean in Eurocode")]
+        [Description("Mean Density. Used to calculate mass. Called p_mean in Eurocode.")]
         public virtual double Density { get; set; }
 
         [Ratio]
@@ -50,7 +50,7 @@ namespace BH.oM.Structure.MaterialFragments
         public virtual double DampingRatio { get; set; }
         
         [YoungsModulus]
-        [Description("Characteristic Modulus Of Elasticity of the material. Ratio between stress and strain in all directions. Vector componets made up of: X - Parallel, E_0,k in Eurocode; Y - Perpendicular, E_90,k in Eurocode; Z - Perpendicular, E_90,k in Eurocode.")]
+        [Description("Characteristic Modulus Of Elasticity of the material. Ratio between stress and strain in all directions. Vector components made up of: X - Parallel, E_0,k in Eurocode; Y - Perpendicular, E_90,k in Eurocode; Z - Perpendicular, E_90,k in Eurocode.")]
         public virtual Vector YoungsModulus { get; set; }
 
         [YoungsModulus]

--- a/Structure_oM/Versioning_60.json
+++ b/Structure_oM/Versioning_60.json
@@ -1,0 +1,27 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+    }
+  },
+  "Property": {
+    "ToNew": {
+      "BH.oM.Structure.MaterialFragments.Timber.DensityDesign": "BH.oM.Structure.MaterialFragments.Timber.DensityCharacteristic"
+    },
+    "ToOld": {
+      "BH.oM.Structure.MaterialFragments.Timber.DensityCharacteristic": "BH.oM.Structure.MaterialFragments.Timber.DensityDesign"
+    }
+  },
+  "MessageForDeleted": {
+  },
+  "MessageForNoUpgrade": {
+  }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per 
Closes #1409 
Closes #1411 

<!-- Add short description of what has been fixed -->
Closes #1409 
Closes #1411 
Added rolling shear property
Changed name of rolling shear from F_v to F_r
Added distinction between characteristic and mean values for all modulus properties. I appreciate this may have been omitted for clarity with US users maybe? @JosefTaylor please have a look and see if my descriptions are suitable for both sides of the pond thanks. 
