### PR TITLE
Physical_oM: Add MaterialTakeoff class

### DIFF
--- a/Physical_oM/Materials/MaterialTakeoff.cs
+++ b/Physical_oM/Materials/MaterialTakeoff.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.oM.Physical.Materials
+{
+    [Description("Defines the make up of an object through a list of Materials and their corresponding volumes." +
+                 "\nThere must be the same number of items in both lists, assigning a single Volume for each Material.")]
+    public class MaterialTakeoff : BHoMObject, IPhysical, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("The Materials that form an object's make up, the order of which corresponds to the order of the Volumes.")]
+        public virtual IReadOnlyList<Material> Materials { get; } = new List<Material>();
+
+        [Volume]
+        [Description("The list of Material Volumes order corresponding to the Materials list, i.e. the amount of each material.")]
+        public virtual IReadOnlyList<double> Volumes { get; } = new List<double>();
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        [Description("The base constructor for MaterialComposition, assigns the properties to the read-only lists.")]
+        public MaterialTakeoff(IEnumerable<Material> materials, IEnumerable<double> volumes)
+        {
+            Materials = materials?.ToList();
+            Volumes = volumes?.ToList();
+        }
+        /***************************************************/
+
+    }
+}
+
+

--- a/Physical_oM/Materials/VolumetricMaterialTakeoff.cs
+++ b/Physical_oM/Materials/VolumetricMaterialTakeoff.cs
@@ -29,9 +29,9 @@ using System.Linq;
 
 namespace BH.oM.Physical.Materials
 {
-    [Description("Defines the make up of an object through a list of Materials and their corresponding volumes." +
-                 "\nThere must be the same number of items in both lists, assigning a single Volume for each Material.")]
-    public class MaterialTakeoff : BHoMObject, IPhysical, IImmutable
+    [Description("Defines the make up of an object through a list of Materials and their corresponding volumes.\n" +
+                 "There must be the same number of items in both lists, assigning a single Volume for each Material.")]
+    public class VolumetricMaterialTakeoff : BHoMObject, IPhysical, IImmutable, IFragment
     {
         /***************************************************/
         /**** Properties                                ****/
@@ -50,7 +50,7 @@ namespace BH.oM.Physical.Materials
         /***************************************************/
 
         [Description("The base constructor for MaterialComposition, assigns the properties to the read-only lists.")]
-        public MaterialTakeoff(IEnumerable<Material> materials, IEnumerable<double> volumes)
+        public VolumetricMaterialTakeoff(IEnumerable<Material> materials, IEnumerable<double> volumes)
         {
             Materials = materials?.ToList();
             Volumes = volumes?.ToList();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1422 

<!-- Add short description of what has been fixed -->

Adds class for MaterialTakeoff. Class for storing a set of materials and the corresponding volumes of said materials.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->