### PR TITLE
LifeCycleAssesment_oM: Add new LCA result classes

### DIFF
--- a/LifeCycleAssessment_oM/Results/ElementResult.cs
+++ b/LifeCycleAssessment_oM/Results/ElementResult.cs
@@ -29,7 +29,7 @@ namespace BH.oM.LifeCycleAssessment.Results
         [Description("The total quantity of the specified Field within the object.")]
         public virtual double Quantity { get; set; }
 
-        [Description("The EPD Field selected for evaluation.")]
+        [Description("The Environmental Product Declaration Field selected for evaluation.")]
         public virtual EnvironmentalProductDeclarationField Metric { get; }
 
         [Description("Result breakdown per material type.")]

--- a/LifeCycleAssessment_oM/Results/ElementResult.cs
+++ b/LifeCycleAssessment_oM/Results/ElementResult.cs
@@ -1,0 +1,93 @@
+﻿using BH.oM.Analytical.Results;
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.Results
+{
+    [Description("Result for a single element from an LCA assesment. Contains total value as well as breakdown per material/EPD evaluated.")]
+    public class ElementResult : IResult, IObjectResult, IResultItem, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Id of the BHoMObject that this result belongs to.")]
+        public virtual IComparable ObjectId { get; } = "";
+
+        [Description("Scope the object this result was generated from belongs to, e.g. Foundation or Facade")]
+        public virtual ScopeType Scope { get; } = ScopeType.Undefined;
+
+        [Description("Category of the object this result was generated from, e.g. Beam or Wall")]
+        public virtual ObjectCategory Category { get; } = ObjectCategory.Undefined;
+
+        [Description("Phase of life abbreviation for the scope of the EPD. A single EnvironmentalMetric can contain either a single Phase or a list of Phases i.e. A1, A2, A3.")]
+        public virtual IReadOnlyList<LifeCycleAssessmentPhases> Phases { get; } = new List<LifeCycleAssessmentPhases>();
+
+        [Description("The total quantity of the specified Field within the object.")]
+        public virtual double Quantity { get; set; }
+
+        [Description("The EPD Field selected for evaluation.")]
+        public virtual EnvironmentalProductDeclarationField Metric { get; }
+
+        [Description("Result breakdown per material type.")]
+        public virtual IReadOnlyList<MaterialResult> MaterialResults { get; }
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public ElementResult(IComparable objectId, ScopeType scope, ObjectCategory category, IReadOnlyList<LifeCycleAssessmentPhases> phases, double quantity, EnvironmentalProductDeclarationField metric, IReadOnlyList<MaterialResult> materialResults)
+        {
+            ObjectId = objectId;
+            Scope = scope;
+            Category = category;
+            Phases = phases;
+            Quantity = quantity;
+            Metric = metric;
+            MaterialResults = materialResults;
+        }
+
+        /***************************************************/
+        /**** IComparable Interface                     ****/
+        /***************************************************/
+
+        public int CompareTo(IResult other)
+        {
+            ElementResult otherRes = other as ElementResult;
+
+            if (otherRes == null)
+                return this.GetType().Name.CompareTo(other.GetType().Name);
+
+            int m = this.Metric.CompareTo(otherRes.Metric);
+            if (m == 0)
+            {
+                int i = this.ObjectId.CompareTo(otherRes.ObjectId);
+                if (i == 0)
+                {
+                    int s = this.Scope.CompareTo(otherRes.Scope);
+                    if (s == 0)
+                    {
+                        return this.Category.CompareTo(otherRes.Category);
+                    }
+                    else
+                    {
+                        return s;
+                    }
+                }
+                else
+                {
+                    return i;
+                }
+            }
+            else
+            {
+                return m;
+            }
+        }
+
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/Results/ElementResult.cs
+++ b/LifeCycleAssessment_oM/Results/ElementResult.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace BH.oM.LifeCycleAssessment.Results
 {
-    [Description("Result for a single element from an LCA assesment. Contains total value as well as breakdown per material/EPD evaluated.")]
+    [Description("Result for a single element from a Life Cycle Assessment. Contains total value as well as breakdown per Material/Environmental Product Declaration evaluated.")]
     public class ElementResult : IResult, IObjectResult, IResultItem, IImmutable
     {
         /***************************************************/
@@ -23,7 +23,7 @@ namespace BH.oM.LifeCycleAssessment.Results
         [Description("Category of the object this result was generated from, e.g. Beam or Wall")]
         public virtual ObjectCategory Category { get; } = ObjectCategory.Undefined;
 
-        [Description("Phase of life abbreviation for the scope of the EPD. A single EnvironmentalMetric can contain either a single Phase or a list of Phases i.e. A1, A2, A3.")]
+        [Description("Phase of life abbreviation for the scope of the Environmental Product Declaration. A single EnvironmentalMetric can contain either a single Phase or a list of Phases i.e. A1, A2, A3.")]
         public virtual IReadOnlyList<LifeCycleAssessmentPhases> Phases { get; } = new List<LifeCycleAssessmentPhases>();
 
         [Description("The total quantity of the specified Field within the object.")]

--- a/LifeCycleAssessment_oM/Results/ElementResult.cs
+++ b/LifeCycleAssessment_oM/Results/ElementResult.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Analytical.Results;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Analytical.Results;
 using BH.oM.Base;
 using System;
 using System.Collections.Generic;

--- a/LifeCycleAssessment_oM/Results/MaterialResult.cs
+++ b/LifeCycleAssessment_oM/Results/MaterialResult.cs
@@ -18,7 +18,7 @@ namespace BH.oM.LifeCycleAssessment.Results
         public virtual string MaterialName { get; }
 
         [Description("Name of the Environmental Product Declaration evaluated.")]
-        public virtual string EPDName { get; }
+        public virtual string EnvironmentalProductDeclarationName { get; }
 
         [Description("The total quantity of the specified Field within the object.")]
         public virtual double Quantity { get; }
@@ -33,10 +33,10 @@ namespace BH.oM.LifeCycleAssessment.Results
         /**** Constructors                              ****/
         /***************************************************/
 
-        public MaterialResult(string materialName, string epdName, IReadOnlyList<LifeCycleAssessmentPhases> phases, double quantity, EnvironmentalProductDeclarationField metric)
+        public MaterialResult(string materialName, string environmentalProductDeclarationName, IReadOnlyList<LifeCycleAssessmentPhases> phases, double quantity, EnvironmentalProductDeclarationField metric)
         {
             MaterialName = materialName;
-            EPDName = epdName;
+            EnvironmentalProductDeclarationName = environmentalProductDeclarationName;
             Phases = phases;
             Quantity = quantity;
             Metric = metric;

--- a/LifeCycleAssessment_oM/Results/MaterialResult.cs
+++ b/LifeCycleAssessment_oM/Results/MaterialResult.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Analytical.Results;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Analytical.Results;
 using BH.oM.Base;
 using System;
 using System.Collections.Generic;

--- a/LifeCycleAssessment_oM/Results/MaterialResult.cs
+++ b/LifeCycleAssessment_oM/Results/MaterialResult.cs
@@ -1,0 +1,77 @@
+﻿using BH.oM.Analytical.Results;
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.Results
+{
+    [Description("Result for a material/epd evaluated..")]
+    public class MaterialResult : IResult, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Name fo the physical material evaluated.")]
+        public virtual string MaterialName { get; }
+
+        [Description("Name fo the EPD material evaluated.")]
+        public virtual string EPDName { get; }
+
+        [Description("The total quantity of the specified Field within the object.")]
+        public virtual double Quantity { get; }
+
+        [Description("Phase of life abbreviation for the scope of the EPD. A single EnvironmentalMetric can contain either a single Phase or a list of Phases i.e. A1, A2, A3.")]
+        public virtual IReadOnlyList<LifeCycleAssessmentPhases> Phases { get; }
+
+        [Description("The EPD Field selected for evaluation.")]
+        public virtual EnvironmentalProductDeclarationField Metric { get; }
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public MaterialResult(string materialName, string epdName, IReadOnlyList<LifeCycleAssessmentPhases> phases, double quantity, EnvironmentalProductDeclarationField metric)
+        {
+            MaterialName = materialName;
+            EPDName = epdName;
+            Phases = phases;
+            Quantity = quantity;
+            Metric = metric;
+        }
+
+        /***************************************************/
+        /**** IComparable Interface                     ****/
+        /***************************************************/
+
+        public int CompareTo(IResult other)
+        {
+            MaterialResult otherRes = other as MaterialResult;
+
+            if (otherRes == null)
+                return this.GetType().Name.CompareTo(other.GetType().Name);
+
+            int n = this.Metric.CompareTo(otherRes.Metric);
+            if (n == 0)
+            {
+                int l = this.MaterialName.CompareTo(otherRes.MaterialName);
+                if (l == 0)
+                {
+                    return this.MaterialName.CompareTo(otherRes.MaterialName);
+                }
+                else
+                {
+                    return l;
+                }
+            }
+            else
+            {
+                return n;
+            }
+        }
+
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/Results/MaterialResult.cs
+++ b/LifeCycleAssessment_oM/Results/MaterialResult.cs
@@ -7,26 +7,26 @@ using System.Text;
 
 namespace BH.oM.LifeCycleAssessment.Results
 {
-    [Description("Result for a material/epd evaluated..")]
+    [Description("Life Cycle Assessment result for a Material/Environmental Product Declaration evaluated.")]
     public class MaterialResult : IResult, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        [Description("Name fo the physical material evaluated.")]
+        [Description("Name of the physical material evaluated.")]
         public virtual string MaterialName { get; }
 
-        [Description("Name fo the EPD material evaluated.")]
+        [Description("Name of the Environmental Product Declaration evaluated.")]
         public virtual string EPDName { get; }
 
         [Description("The total quantity of the specified Field within the object.")]
         public virtual double Quantity { get; }
 
-        [Description("Phase of life abbreviation for the scope of the EPD. A single EnvironmentalMetric can contain either a single Phase or a list of Phases i.e. A1, A2, A3.")]
+        [Description("Phase of life abbreviation for the scope of the Environmental Product Declaration. A single EnvironmentalMetric can contain either a single Phase or a list of Phases i.e. A1, A2, A3.")]
         public virtual IReadOnlyList<LifeCycleAssessmentPhases> Phases { get; }
 
-        [Description("The EPD Field selected for evaluation.")]
+        [Description("The Environmental Product Declaration Field selected for evaluation.")]
         public virtual EnvironmentalProductDeclarationField Metric { get; }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1448

<!-- Add short description of what has been fixed -->

Adding new LCA result classes:
- ElementResult - can replace the current result class if this PR is accepted. Stores information about how to identify the result as well as total quantity and a breakdown of quantity evaluated per material.
- MaterialResult - New result class, storing information about quantity per material. Can be per element as part of ElementResult or total for a particular material.

Adding as new classes as a first step. If agreed we could replace the current ResultClasses in the oM.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->