### PR TITLE
Physical_oM: Add MeshElement

### DIFF
--- a/Physical_oM/Elements/MeshElement.cs
+++ b/Physical_oM/Elements/MeshElement.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.oM.Physical.Elements
+{
+    [Description("Element defined by a geometrical mesh defining the 3-dimensional geometry of the element.\n" +
+                 "Can commonly store properties and parameters in fragments corresponding to the software from which the element was extracted.")]
+    public class MeshElement : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Mesh defining the full 3-dimensional geometry of the element.")]
+        public virtual Mesh Mesh { get; set; } = null;
+
+        /***************************************************/
+
+    }
+}
+
+

--- a/Physical_oM/Elements/MeshElement.cs
+++ b/Physical_oM/Elements/MeshElement.cs
@@ -29,7 +29,7 @@ using System.ComponentModel;
 
 namespace BH.oM.Physical.Elements
 {
-    [Description("Element defined by a geometrical mesh defining the 3-dimensional geometry of the element.\n" +
+    [Description("Object representing a physical element, defined by a geometrical mesh that represents that element in 3-dimensional space.\n" +
                  "Can commonly store properties and parameters in fragments corresponding to the software from which the element was extracted.")]
     public class MeshElement : BHoMObject
     {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1451

<!-- Add short description of what has been fixed -->

Adding a simple `MeshElement` class. First use case to be able to make a simplified representation of BIM objects, where parameters are to be stored in software specific fragments, and the Mesh property is to host the mesh representation of the object.

### Test files
<!-- Link to test files to validate the proposed changes -->

To be tested in anger in various workflows in other toolkits. For this first push just good to get the object in for which code review should suffice.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->