### PR TITLE
Facade_oM: Add UValueCavity Fragment

### DIFF
--- a/Facade_oM/Fragments/UValueCavity.cs
+++ b/Facade_oM/Fragments/UValueCavity.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using System.ComponentModel;
+
+namespace BH.oM.Facade.Fragments
+{
+	[Description("A U-Value representing the effective U-Value of cavity insulation. This does not include derating effects from any frame u-values but should be derated for any thermal bridges not modeled.")]
+	public class UValueCavity : IFragment
+    {
+		[Description("The U-Value of the cavity insulation.")]
+		public virtual double UValue { get; set; } = double.NaN;
+	}
+}

--- a/Facade_oM/Fragments/UValueCavity.cs
+++ b/Facade_oM/Fragments/UValueCavity.cs
@@ -30,10 +30,10 @@ using System.ComponentModel;
 
 namespace BH.oM.Facade.Fragments
 {
-	[Description("A U-Value representing the effective U-Value of cavity insulation. This does not include derating effects from any frame u-values but should be derated for any thermal bridges not modeled.")]
-	public class UValueCavity : IFragment
+    [Description("A U-Value representing the effective U-Value of cavity insulation. This does not include derating effects from any frame u-values but should be derated for any thermal bridges not modeled.")]
+    public class UValueCavity : IFragment
     {
-		[Description("The U-Value of the cavity insulation.")]
-		public virtual double UValue { get; set; } = double.NaN;
-	}
+        [Description("The U-Value of the cavity insulation.")]
+        public virtual double UValue { get; set; } = double.NaN;
+    }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1424 

<!-- Add short description of what has been fixed -->
Adds new fragment UValueCavity which represents the u-value of cavity insulation which is not continuous across frameedges.