### PR TITLE
Structure_oM: Add new surface properties

### DIFF
--- a/Structure_oM/SurfaceProperties/BiDirectionalVoided.cs
+++ b/Structure_oM/SurfaceProperties/BiDirectionalVoided.cs
@@ -42,14 +42,14 @@ namespace BH.oM.Structure.SurfaceProperties
         public virtual double TopThickness { get; set; }
 
         [Length]
-        [Description("The thickness of the slab sitting beneth the ribs.")]
+        [Description("The thickness of the slab sitting beneath the ribs.")]
         public virtual double BottomThickness { get; set; }
 
         [Description("Homogenous structural material throughout the full thickness of the element.")]
         public virtual IMaterialFragment Material { get; set; }
 
         [Length]
-        [Description("Total depth measured from the bottom of the ribs to the top of the slab.")]
+        [Description("Total depth measured from the bottom of the lower slab to the top of the upper slab")]
         public virtual double TotalDepth { get; set; }
 
         [Length]

--- a/Structure_oM/SurfaceProperties/BiDirectionalVoided.cs
+++ b/Structure_oM/SurfaceProperties/BiDirectionalVoided.cs
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Structure.MaterialFragments;
+using System.ComponentModel;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.oM.Structure.SurfaceProperties
+{
+    [Description("Property for 2D analytical elements, made up of two slabs with parallel ribs running in two directions between them, all sharing the same material.")]
+    public class BiDirectionalVoided : BHoMObject, ISurfaceProperty
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("A unique Name is required for some structural packages to create and identify the object.")]
+        public override string Name { get; set; }
+
+        [Length]
+        [Description("The thickness of the slab sitting on top of the ribs.")]
+        public virtual double TopThickness { get; set; }
+
+        [Length]
+        [Description("The thickness of the slab sitting beneth the ribs.")]
+        public virtual double BottomThickness { get; set; }
+
+        [Description("Homogenous structural material throughout the full thickness of the element.")]
+        public virtual IMaterialFragment Material { get; set; }
+
+        [Length]
+        [Description("Total depth measured from the bottom of the ribs to the top of the slab.")]
+        public virtual double TotalDepth { get; set; }
+
+        [Length]
+        [Description("Width of each rib in local x-direction.")]
+        public virtual double StemWidthX { get; set; }
+
+        [Length]
+        [Description("Width of each rib in local y-direction.")]
+        public virtual double StemWidthY { get; set; }
+
+        [Length]
+        [Description("Centre-Centre distance between the ribs running in local x-direction.")]
+        public virtual double SpacingX { get; set; }
+
+        [Length]
+        [Description("Centre-Centre distance between the ribs running in local y-direction.")]
+        public virtual double SpacingY { get; set; }
+
+        [Description("Defines what type of element this property will be used. Used by some analysis packages.")]
+        public virtual PanelType PanelType { get; set; } = PanelType.Slab;
+
+
+        /***************************************************/
+    }
+}
+
+
+
+

--- a/Structure_oM/SurfaceProperties/HollowCore.cs
+++ b/Structure_oM/SurfaceProperties/HollowCore.cs
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Structure.MaterialFragments;
+using System.ComponentModel;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.oM.Structure.SurfaceProperties
+{
+    [Description("Property for 2D analytical elements, made up of a fixed thickness slab of homogenous material, with a series of parallel holes through it in a particular direction.")]
+    public class HollowCore : BHoMObject, ISurfaceProperty
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("A unique Name is required for some structural packages to create and identify the object.")]
+        public override string Name { get; set; }
+
+        [Length]
+        [Description("Defines the distance the element should be extruded along its normal. By default the element will be extruded half the thickness 'upwards' and half the thickness 'downwards' meaning the element base geoemtry will be in the centre of the extrusion.")]
+        public virtual double Thickness { get; set; }
+
+        [Description("Homogenous structural material throughout the full thickness of the element.")]
+        public virtual IMaterialFragment Material { get; set; }
+
+        [Description("Defines what type of element this property will be used. Used by some analysis packages.")]
+        public virtual PanelType PanelType { get; set; } = PanelType.Slab;
+
+        [Description("Openings of the hollow core.")]
+        public virtual IHollowCoreOpeningProfiles Openings { get; set; }
+
+        /***************************************************/
+    }
+}
+
+
+
+

--- a/Structure_oM/SurfaceProperties/HollowCoreOpeningProfiles/CircularHollowCoreOpeningProfiles.cs
+++ b/Structure_oM/SurfaceProperties/HollowCoreOpeningProfiles/CircularHollowCoreOpeningProfiles.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.Structure.SurfaceProperties
+{
+    public class CircularHollowCoreOpeningProfiles : BHoMObject, IHollowCoreOpeningProfiles
+    {
+        [Length]
+        [Description("Diameter of the opening.")]
+        public virtual double Diameter { get; set; }
+
+        [Length]
+        [Description("Centre-centre distance between openings.")]
+        public virtual double Spacing { get; set; }
+
+    }
+}

--- a/Structure_oM/SurfaceProperties/HollowCoreOpeningProfiles/ElongatedCircularHollowCoreOpeningProfiles.cs
+++ b/Structure_oM/SurfaceProperties/HollowCoreOpeningProfiles/ElongatedCircularHollowCoreOpeningProfiles.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.Structure.SurfaceProperties
+{
+    public class ElongatedCircularHollowCoreOpeningProfiles : BHoMObject, IHollowCoreOpeningProfiles
+    {
+
+        [Length]
+        [Description("Total height of the opening.")]
+        public virtual double Height { get; set; }
+
+        [Length]
+        [Description("Width of the opening. Will also be the diameter of the circular end bits of the opening.")]
+        public virtual double Width { get; set; }
+
+        [Length]
+        [Description("Centre-centre distance between openings.")]
+        public virtual double Spacing { get; set; }
+
+    }
+}

--- a/Structure_oM/SurfaceProperties/HollowCoreOpeningProfiles/IHollowCoreProfile.cs
+++ b/Structure_oM/SurfaceProperties/HollowCoreOpeningProfiles/IHollowCoreProfile.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BH.oM.Structure.SurfaceProperties
+{
+    public interface IHollowCoreOpeningProfiles : IBHoMObject
+    {
+    }
+}

--- a/Structure_oM/SurfaceProperties/OneDirectionalVoided.cs
+++ b/Structure_oM/SurfaceProperties/OneDirectionalVoided.cs
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Structure.MaterialFragments;
+using System.ComponentModel;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.oM.Structure.SurfaceProperties
+{
+    [Description("Property for 2D analytical elements, made up of two slabs with parallel ribs running in one direction between them, all sharing the same material.")]
+    public class OneDirectionalVoided : BHoMObject, ISurfaceProperty
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("A unique Name is required for some structural packages to create and identify the object.")]
+        public override string Name { get; set; }
+
+        [Length]
+        [Description("The thickness of the slab sitting on top of the ribs.")]
+        public virtual double TopThickness { get; set; }
+
+        [Length]
+        [Description("The thickness of the slab sitting beneth the ribs.")]
+        public virtual double BottomThickness { get; set; }
+
+        [Description("Homogenous structural material throughout the full thickness of the element.")]
+        public virtual IMaterialFragment Material { get; set; }
+
+        [Description("Specifies if the ribs are running in local x or y direction.")]
+        public virtual PanelDirection Direction { get; set; } = PanelDirection.X;
+
+        [Length]
+        [Description("Total depth measured from the bottom of the ribs to the top of the slab.")]
+        public virtual double TotalDepth { get; set; }
+
+        [Length]
+        [Description("Width of each rib.")]
+        public virtual double StemWidth { get; set; }
+
+        [Length]
+        [Description("Centre-centre distance between the ribs. Measured perpendicular to the rib direction.")]
+        public virtual double Spacing { get; set; }
+
+        [Description("Defines what type of element this property will be used. Used by some analysis packages.")]
+        public virtual PanelType PanelType { get; set; } = PanelType.Slab;
+
+
+        /***************************************************/
+    }
+}
+
+
+
+

--- a/Structure_oM/SurfaceProperties/OneDirectionalVoided.cs
+++ b/Structure_oM/SurfaceProperties/OneDirectionalVoided.cs
@@ -42,7 +42,7 @@ namespace BH.oM.Structure.SurfaceProperties
         public virtual double TopThickness { get; set; }
 
         [Length]
-        [Description("The thickness of the slab sitting beneth the ribs.")]
+        [Description("The thickness of the slab sitting beneath the ribs.")]
         public virtual double BottomThickness { get; set; }
 
         [Description("Homogenous structural material throughout the full thickness of the element.")]
@@ -52,7 +52,7 @@ namespace BH.oM.Structure.SurfaceProperties
         public virtual PanelDirection Direction { get; set; } = PanelDirection.X;
 
         [Length]
-        [Description("Total depth measured from the bottom of the ribs to the top of the slab.")]
+        [Description("Total depth measured from the bottom of the lower slab to the top of the upper slab")]
         public virtual double TotalDepth { get; set; }
 
         [Length]

--- a/Structure_oM/SurfaceProperties/ToppedSlab.cs
+++ b/Structure_oM/SurfaceProperties/ToppedSlab.cs
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Structure.MaterialFragments;
+using System.ComponentModel;
+using BH.oM.Quantities.Attributes;
+
+namespace BH.oM.Structure.SurfaceProperties
+{
+    [Description("Property for 2D analytical elements, made up of a slab property with concrete topping.")]
+    public class ToppedSlab : BHoMObject, ISurfaceProperty
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("A unique Name is required for some structural packages to create and identify the object.")]
+        public override string Name { get; set; }
+
+        [Description("Base property which is being topped.")]
+        public virtual ISurfaceProperty BaseProperty { get; set; } = null;
+
+        [Length]
+        [Description("Thickness of the topping added on top of the base surface property.")]
+        public virtual double ToppingThickness { get; set; }
+
+        [Description("Material for the topping of the slab.")]
+        public virtual IMaterialFragment Material { get; set; }
+
+        [Description("Defines what type of element this property will be used. Used by some analysis packages.")]
+        public virtual PanelType PanelType { get; set; } = PanelType.Slab;
+
+        /***************************************************/
+    }
+}
+
+
+
+


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1480 
Closes #1481 

<!-- Add short description of what has been fixed -->

Adds a series of new SurfacePropery classes.

- Voided: One and two directional
- Hollow core (with a first two common opening profile types)
- Topped slab, to enable for example a precast slab with concrete topping.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EnlCAJUsxb5Ckyaz48Avm1gBomY2EBiRpl1Fy8Vemwwozg?e=YoFIFQ

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->