### PR TITLE
Structure_oM: adding a new DistanceIsParametric `bool` property to `BarPointLoad`

### DIFF
--- a/Structure_oM/Loads/BarPointLoad.cs
+++ b/Structure_oM/Loads/BarPointLoad.cs
@@ -36,8 +36,12 @@ namespace BH.oM.Structure.Loads
         /***************************************************/
 
         [Length]
-        [Description("Distance along the Bar between the StartNode and the load position.")]
+        [Description("Distance along the Bar between the StartNode and the load position." +
+            "If `DistanceIsParametric` is true, this is a number between 0 and 1 defining the parametric distance along the Bar.")]
         public virtual double DistanceFromA { get; set; } = 0;
+
+        [Description("Whether the DistanceFromA is to be intended as absolute or parametric. Defaults to false.")]
+        public virtual bool DistanceIsParametric { get; set; } = false;
 
         [Force]
         [Description("Magnitude and direction of the Force. The load requires the Force and/or the Moment Vector to be non-zero to have any effect.")]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1427

<!-- Add short description of what has been fixed -->
Adds a new `DistanceIsParametric` boolean to `BarPointLoad` to clarify whether `DistanceFromA` property is parametric or absolute. Adjusts the description to match.

### Test files
<!-- Link to test files to validate the proposed changes -->
No workflows support this yet. Done in support of https://github.com/BHoM/Karamba3D_Toolkit/pull/4#discussion_r1116882312.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->