### PR TITLE
BHoM: Have compiling BHoM make a Settings directory.

### DIFF
--- a/BHoM/BHoM.csproj
+++ b/BHoM/BHoM.csproj
@@ -13,6 +13,6 @@
     <OutputPath>..\Build\</OutputPath>
   </PropertyGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="mkdir &quot;C:\ProgramData\BHoM\Assemblies&quot;&#xD;&#xA;mkdir &quot;C:\ProgramData\BHoM\Datasets&quot;&#xD;&#xA;mkdir &quot;C:\ProgramData\BHoM\Upgrades&quot;&#xD;&#xA;&#xD;&#xA;xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
+    <Exec Command="mkdir &quot;C:\ProgramData\BHoM\Assemblies&quot;&#xD;&#xA;mkdir &quot;C:\ProgramData\BHoM\Datasets&quot;&#xD;&#xA;mkdir &quot;C:\ProgramData\BHoM\Upgrades&quot;&#xD;&#xA;mkdir &quot;C:\ProgramData\BHoM\Settings&quot;&#xD;&#xA;&#xD;&#xA;xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
   </Target>
 </Project>


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #1489 

### Test files

Steps to test:

 - Delete your `C:\ProgramData\BHoM\Settings` folder (or rename it) and try to open BHoM in Grasshopper
   - You should get invocation errors, and the BHoM ribbon is devoid of any useful content
 - Compile this PR
   - You should get an empty `Settings` folder in `C:\ProgramData\BHoM`
 - Open Grasshopper
   - You should get 0 errors, and the BHoM ribbon should have its usual content