### PR TITLE
Lighting_oM: Changed Luminaire Orientation Property name and Type to Basis to Align with similar Elements

### DIFF
--- a/Lighting_oM/Elements/Luminaire.cs
+++ b/Lighting_oM/Elements/Luminaire.cs
@@ -45,7 +45,7 @@ namespace BH.oM.Lighting.Elements
         public virtual string Type { get; set; } = "";
 
         [Description("The direction that the Luminaire is oriented towards.")]
-        public virtual Vector Direction { get; set; } = new Vector();
+        public virtual Basis Orientation { get; set; } = new Basis(Vector.XAxis, Vector.YAxis, Vector.ZAxis);
 
         [Description("The Luminaire Type applied to the Luminaire.")]
         public virtual LuminaireType LuminaireType { get; set; } = new LuminaireType();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1500 

As per the title, the Property previously named Direction has been changed to a Property named Orientation with type Basis.

