### PR TITLE
Structure_oM: Add direction enum to HollowCore

### DIFF
--- a/Structure_oM/SurfaceProperties/HollowCore.cs
+++ b/Structure_oM/SurfaceProperties/HollowCore.cs
@@ -50,6 +50,9 @@ namespace BH.oM.Structure.SurfaceProperties
         [Description("Openings of the hollow core.")]
         public virtual IHollowCoreOpeningProfiles Openings { get; set; }
 
+        [Description("Specifies if the hollow cores are running in local x or y direction.")]
+        public virtual PanelDirection Direction { get; set; } = PanelDirection.X;
+
         /***************************************************/
     }
 }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1504

<!-- Add short description of what has been fixed -->

Adds direction enum to the hollow core surface property

### Test files
<!-- Link to test files to validate the proposed changes -->



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->