### PR TITLE
LifeCycleAssesment_oM: Add message for deleted for implicitly removed properties

### DIFF
--- a/LifeCycleAssessment_oM/Versioning_62.json
+++ b/LifeCycleAssessment_oM/Versioning_62.json
@@ -1,0 +1,30 @@
+{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Property": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "MessageForDeleted": {
+    "BH.oM.LifeCycleAssessment.LifeCycleAssessmentScope.CustomData": "Object no longer inheriting from BHoMObject, which means all base properties from the BHoMObject no longer exist and is seen as removed.",
+    "BH.oM.LifeCycleAssessment.LifeCycleAssessmentScope.BHoM_Guid": "Object no longer inheriting from BHoMObject, which means all base properties from the BHoMObject no longer exist and is seen as removed.",
+    "BH.oM.LifeCycleAssessment.LifeCycleAssessmentScope.Name": "Object no longer inheriting from BHoMObject, which means all base properties from the BHoMObject no longer exist and is seen as removed.",
+    "BH.oM.LifeCycleAssessment.LifeCycleAssessmentScope.Fragments": "Object no longer inheriting from BHoMObject, which means all base properties from the BHoMObject no longer exist and is seen as removed.",
+    "BH.oM.LifeCycleAssessment.LifeCycleAssessmentScope.Tags": "Object no longer inheriting from BHoMObject, which means all base properties from the BHoMObject no longer exist and is seen as removed."
+
+  },
+  "MessageForNoUpgrade": {
+  }
+}


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1512

<!-- Add short description of what has been fixed -->

As stated in issue:

The LifeCycleAssessmentScope was changed from a BHoMObject to not a BHoMObject a few versions ago.

With the new improved [Serialiser_Engine](https://github.com/BHoM/BHoM_Engine/pull/3042) this is flagged up as an issue requiring versioning, which is correct as the data for the base properties has nowhere to be put.

Message for deleted is to be added for all of those properties.

This is not really relating to versioning happening in 6.2, but think it is still fine to add here as it is the serialisation fixes that helps this getting flagged.

This will not trigger on main/dev branches, but still think it is fine to merge in before Serialiser_Engine as it wont hurt anything. 

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->