### PR TITLE
Base_oM: Add IImutbale interface to Enumeration class

### DIFF
--- a/BHoM/Enumeration.cs
+++ b/BHoM/Enumeration.cs
@@ -27,7 +27,7 @@ using System.Reflection;
 
 namespace BH.oM.Base
 {
-    public abstract class Enumeration : IObject, IEnum 
+    public abstract class Enumeration : IObject, IEnum, IImmutable
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1514

<!-- Add short description of what has been fixed -->

The class is relying on the constructor for de-serialisation, and should hence be implementing IImutable interface.

Before https://github.com/BHoM/BHoM_Engine/pull/3042 this could be picked up be default class mapping by mongo, but even for that case, really should be tagged to be explicitly handled by us.

After the serialisation refactoring the interface is fully required for deserialsiation.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->