### PR TITLE
Phsyical_oM: Adds a general Material Takeoff object

### DIFF
--- a/Physical_oM/Materials/GeneralMaterialTakeoff.cs
+++ b/Physical_oM/Materials/GeneralMaterialTakeoff.cs
@@ -1,0 +1,81 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.oM.Physical.Materials
+{
+    [Description("Defines the make up of an object through a list of Materials and their corresponding quantities corresponding to each material.")]
+    public class GeneralMaterialTakeoff : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("List of the the materials with corresponding qunatities relevant to the particular material.")]
+        public virtual List<TakeoffItem> MaterialTakeoffItems { get; set; } = new List<TakeoffItem>();
+
+
+        /***************************************************/
+        /**** Explicit Casting                          ****/
+        /***************************************************/
+
+        [Description("Converts a VolumetricMaterialTakeoff to a GeneralMaterialTakeoff, collection information about Material, volume and mass as well as general BHoM properties from the Volumetric takeoff. All other properties are set to default values.")]
+        public static explicit operator GeneralMaterialTakeoff(VolumetricMaterialTakeoff volTakeoff)
+        {
+            if(volTakeoff == null)
+                return null;
+
+            List<TakeoffItem> items = new List<TakeoffItem>();
+
+            for (int i = 0; i < volTakeoff.Materials.Count; i++)
+            {
+                Material mat = volTakeoff.Materials[i];
+                double volume = volTakeoff.Volumes[i];
+                items.Add(new TakeoffItem
+                {
+                    Material = mat,
+                    Volume = volume,
+                    Mass = volume*mat.Density
+                });
+            }
+
+            return new GeneralMaterialTakeoff 
+            {
+                MaterialTakeoffItems  = items, 
+                CustomData = new Dictionary<string, object>(volTakeoff.CustomData),
+                Name = volTakeoff.Name,
+                Tags = new HashSet<string>(volTakeoff.Tags),
+                Fragments = new FragmentSet(volTakeoff.Fragments)
+            };
+        }
+
+        /***************************************************/
+
+    }
+}
+
+

--- a/Physical_oM/Materials/TakeoffItem.cs
+++ b/Physical_oM/Materials/TakeoffItem.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.oM.Physical.Materials
+{
+    [Description("Class storing takeoff values of relevant quantities corresponding to a particular material.")]
+    public class TakeoffItem : IObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Material to which the takeoff values correspond.")]
+        public virtual Material Material { get; set; }
+
+        [Volume]
+        [Description("Total volume of the material. Applicable for most takeoffs.")]
+        public virtual double Volume { get; set; } = double.NaN;
+
+        [Mass]
+        [Description("Total mass of the material. Applicable for materials with a set density.")]
+        public virtual double Mass { get; set; } = double.NaN;
+
+        [Area]
+        [Description("Total area of the material. Applicable for takeoffs of 2-dimensional elements or 2-dimensional parts.")]
+        public virtual double Area { get; set; } = double.NaN;
+
+        [Length]
+        [Description("Total length of the material. Applicable for takeoffs of 1-dimensional elements or elements with 1-dimensional parts.")]
+        public virtual double Length { get; set; } = double.NaN;
+
+        [Description("Total number of items containing the material in the takeoff. Applicable for most takeoffs.")]
+        public virtual int NumberItem { get; set; } = 0;
+
+        [ElectricCurrent]
+        [Description("Total Electric current associated with the material. Applicable for takeoffs of some electrical equipment elements.")]
+        public virtual double ElectricCurrent { get; set; } = double.NaN;
+
+        [Energy]
+        [Description("Total Electric current associated with the material. Applicable for takeoffs of some electrical equipment elements.")]
+        public virtual double Energy { get; set; } = double.NaN;
+
+        [EnergyPerUnitTime]
+        [Description("Total Power or apparent power associated with the material. Applicable for takeoffs of some electrical equipment elements.")]
+        public virtual double Power { get; set; } = double.NaN;
+
+        [VolumetricFlowRate]
+        [Description("Total VolumetricFlowRate associated with the material. Applicable for takeoffs of elements relating to flow of substance through the element.")]
+        public virtual double VolumetricFlowRate { get; set; } = double.NaN;
+
+
+        /***************************************************/
+
+    }
+}
+
+


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1502 

<!-- Add short description of what has been fixed -->

Adds a general takeoff object able to store a multitude of quantities associated with a particular material

Done in support of https://github.com/BHoM/LifeCycleAssessment_Toolkit/pull/314 to help further simply evaluation process and remove last bits of takeoff responsibility from the LCA_Engine.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Physical_oM/%231516-AddGeneralTakeoffObject?csf=1&web=1&e=iAsS7e

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->