### PR TITLE
Diffing_oM: null coalescence of optional Diff constructor parameters added

### DIFF
--- a/Diffing_oM/Diff.cs
+++ b/Diffing_oM/Diff.cs
@@ -71,8 +71,8 @@ namespace BH.oM.Diffing
             RemovedObjects = removedObjects;
             ModifiedObjects = modifiedObjects;
             DiffingConfig = diffingConfig;
-            ModifiedObjectsDifferences = modifiedObjectsDifferences;
-            UnchangedObjects = unchangedObjects;
+            ModifiedObjectsDifferences = modifiedObjectsDifferences ?? new List<ObjectDifferences>();
+            UnchangedObjects = unchangedObjects ?? new List<object>();
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1546

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Standard test procedure for diffing.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->