### PR TITLE
Facade_oM: Updated OpeningType enums

### DIFF
--- a/Facade_oM/Elements/Enums/OpeningType.cs
+++ b/Facade_oM/Elements/Enums/OpeningType.cs
@@ -28,16 +28,12 @@ namespace BH.oM.Facade.Elements
     public enum OpeningType
     {
         Undefined,
-        CurtainWall,
+        CurtainWallVision,
+        CurtainWallSpandrel,
         Door,
-        Frame,
-        Glazing,
         Hole,
-        Rooflight,
-        RooflightWithFrame,
+        Skylight,
         Window,
-        WindowWithFrame,
-        VehicleDoor,
     }
 }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Related to https://github.com/BHoM/BHoM_Engine/issues/3145

<!-- Add short description of what has been fixed -->
- Added new enum OpeningTypes required to run new spandrel calculation methods on BHoM_Engine.
- Deleted obsolete OpeningType enums.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_Engine/Facade_Engine/BHoM%20PR%20Test%20Files/230906_SpandrelAWTestFile.gh?csf=1&web=1&e=1rxpMK) 