### PR TITLE
BHoM: Update documentation links and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 # Core BHoM Repo
 
 This repo is part of the Buildings and Habitats object Model. 
-If you are new (_welcome!_  👋 😄)  a great place to start is on [bhom.xyz](https://bhom.xyz) or reading our [wiki here](https://github.com/BHoM/documentation/wiki) including pages like the [Structure of the BHoM](https://github.com/BHoM/documentation/wiki/Structure-of-the-BHoM) and [Using the BHoM](https://github.com/BHoM/documentation/wiki/Using-the-BHoM).
+If you are new (_welcome!_  👋 😄)  a great place to start is on [bhom.xyz](https://bhom.xyz) or reading our [wiki here](https://bhom.xyz/documentation) including pages like the [Structure of the BHoM](https://bhom.xyz/documentation/Basics/Coding%20fundamentals/The-BHoM-code-organisation/) and [Using the BHoM](https://bhom.xyz/documentation/Basics/Using-the-BHoM/).
 
 This particular repo contains all of the core _object Model_ (oM) definitions. Our community curated common language.
 
-The objects themselves are designed to be very simple, and therefore flexible and customisable. Comprising of nothing more than a list of defining properties. See [defining objects in the oM](https://github.com/BHoM/documentation/wiki/BH.oM-%E2%80%90-Define-New-Objects) for more details.
+The objects themselves are designed to be very simple, and therefore flexible and customisable. Comprising of nothing more than a list of defining properties. See [defining objects in the oM](https://bhom.xyz/documentation/BHoM_oM/) for more details.
 
 The core BHoM contains objects from wide ranging domains across the disciplines of engineering, architecture, our environment and the physical world, as well as defining concepts within programming, machine learning, mathematics, geometry and planning to name a few.
 
@@ -23,7 +23,7 @@ Grab the [latest installer](https://bhom.xyz/) and a selection of [sample script
 ## Getting Started for Developers 🤖 
 
 If you want to build the BHoM and the Toolkits from source, it's hopefully easy! 😄 
-Do take a look at our specific wiki pages here: [Getting Started for Developers](https://github.com/BHoM/documentation/wiki/Getting-started-for-developers)
+Do take a look at our specific wiki pages here: [Getting Started for Developers](https://bhom.xyz/documentation/Contributing/Getting-started-for-developers/)
 
 
 ## Want to Contribute? ##
@@ -36,4 +36,4 @@ BHoM is an open-source project and would be nothing without its community. Take 
 BHoM is free software licenced under GNU Lesser General Public Licence - [https://www.gnu.org/licenses/lgpl-3.0.html](https://www.gnu.org/licenses/lgpl-3.0.html)  
 Each contributor holds copyright over their respective contributions.
 The project versioning (Git) records all such contribution source information.
-See [LICENSE](https://github.com/BHoM/BHoM/blob/master/LICENSE) and [COPYRIGHT_HEADER](https://github.com/BHoM/BHoM/blob/master/COPYRIGHT_HEADER.txt).
+See [LICENSE](https://github.com/BHoM/BHoM/blob/main/LICENSE) and [COPYRIGHT_HEADER](https://github.com/BHoM/BHoM/blob/main/COPYRIGHT_HEADER.txt).

--- a/docs/CODE_OF_CONDUCT_FOR_BOTS.md
+++ b/docs/CODE_OF_CONDUCT_FOR_BOTS.md
@@ -1,5 +1,5 @@
 # BHoM Code of Conduct for Bots
-If you are looking for the Code of Conduct for human contributors to the BHoM framework please refer to the version  [here](https://github.com/BHoM/BHoM/blob/master/docs/CODE_OF_CONDUCT.md).   
+If you are looking for the Code of Conduct for human contributors to the BHoM framework please refer to the version  [here](https://github.com/BHoM/BHoM/blob/main/docs/CODE_OF_CONDUCT.md).   
 
 The following guidelines are designed with reference to (but whose scope is not limited to) the defined use of @BHoMBot and other bots as part of BHoM continuous integration, continuous delivery and automation of coding support and maintenance. 
 
@@ -10,7 +10,7 @@ Bots posting comments, messages or reporting across any BHoM GitHub Organisation
 
 *   Comments from bots should remain objective, documenting events and factual status reports.
 *   Bots should not express opinions - including re-posting or perpetuating comments from other users.
-*   Any language adopted by bots must adhere to the exact same values as outlined in our [standard code of conduct](https://github.com/BHoM/BHoM/blob/master/docs/CODE_OF_CONDUCT.md). 
+*   Any language adopted by bots must adhere to the exact same values as outlined in our [standard code of conduct](https://github.com/BHoM/BHoM/blob/main/docs/CODE_OF_CONDUCT.md). 
 *   Bots may ask closed, specific questions, to which a positive response may trigger a further interaction or a series of well documented, automated events.
 *   Bot responses should be logical, consistent and conform to a user's general expectations regardless of documentation. Surprises or causing confusion is bad.
 *   A bot can not modify another author's Branch or raised Pull Request unless directly instructed by an authorized user. 
@@ -21,7 +21,7 @@ Authorized users in this context will refer to:
 1. Code Owner  
 1. Administrators and Maintainers  
 
-For more details on code roles and governance see document [here](https://github.com/BHoM/BHoM/blob/master/docs/GOVERNANCE.md).
+For more details on code roles and governance see document [here](https://github.com/BHoM/BHoM/blob/main/docs/GOVERNANCE.md).
 
 
 As with _any_ remote and online dialogue these rules are designed to be explicitly mindful of the inherent lack of contextual information. 
@@ -29,7 +29,7 @@ The BHoM community aims for bot interaction with other users to be in direct sup
 
 ## User Interactions with Bots
 
-Any communication with bots must meet the exact same expectations as outlined in our [standard code of conduct](https://github.com/BHoM/BHoM/blob/master/docs/CODE_OF_CONDUCT.md), and are subject to enforcement in the same way. 
+Any communication with bots must meet the exact same expectations as outlined in our [standard code of conduct](https://github.com/BHoM/BHoM/blob/main/docs/CODE_OF_CONDUCT.md), and are subject to enforcement in the same way. 
 
 ## Bots and CI
 
@@ -55,5 +55,5 @@ Reporting issues or questions related to @BHoMBot and other automated governance
 
   &nbsp;  @al-fisher  
   &nbsp;  @adecler  
+  &nbsp;  @FraserGreenroyd  
   &nbsp;  @rwemay  
-

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -7,7 +7,7 @@ Contributions are very welcome and warmly encouraged either from outside of the 
 The current core maintainers are listed below, however we are actively interested in other members joining to expand and support further at every level. If interested please get in touch. You can do this through contacting individual maintainers or emailing hello@bhom.xyz or simply raising issues or submitting code. 
 
 
-If you should have any queries around best practices in contributing or commenting on code, issues, PRs etc. please see our [Code of Conduct document here](https://github.com/BHoM/BHoM/blob/master/docs/CODE_OF_CONDUCT.md).
+If you should have any queries around best practices in contributing or commenting on code, issues, PRs etc. please see our [Code of Conduct document here](https://github.com/BHoM/BHoM/blob/main/docs/CODE_OF_CONDUCT.md).
 
 ## Organisation Maintainers 
 
@@ -33,21 +33,21 @@ Typical activities of a Repository Maintainer include:
 
 
 A number of the key repositories and/or individual namespaces are summarised below. However for more detail on individual responsibilities for code within the core oM and Engine repositories please refer to the local CODEOWNERS documents.
-In particular, for granular breakdown for the Core Repositories see direct links [BHoM Repository Code Owners](https://github.com/BHoM/BHoM/blob/master/docs/CODEOWNERS) and [BHoM_Engine Repository Code Owners](https://github.com/BHoM/BHoM_Engine/blob/master/docs/CODEOWNERS).
+In particular, for granular breakdown for the Core Repositories see direct links [BHoM Repository Code Owners](https://github.com/BHoM/BHoM/blob/main/docs/CODEOWNERS) and [BHoM_Engine Repository Code Owners](https://github.com/BHoM/BHoM_Engine/blob/main/docs/CODEOWNERS).
 
 
 
 
 #### Domain/Discipline Namespaces 
 
-* Core & Framework  &nbsp;  @adecler
+* Core & Framework  &nbsp;  @adecler & @FraserGreenroyd
 * Structure oM/Engine  &nbsp;  @IsakNaslundBh  
-* Environment oM/Engine  &nbsp;  @FraserGreenroyd
+* Environment oM/Engine  &nbsp;  @FraserGreenroyd & @JamesRamsden-BH
 * Geometery & BIM &nbsp;  @pawelbaran 
-* Data oM & Machine Learning &nbsp;  @epignatelli  
+* Data oM & Machine Learning &nbsp;  @alelom  
 * BHoM_Adapter & Interoperability  &nbsp;  @alelom
 * Structural_Adapters  &nbsp;  @IsakNaslundBh  
-* Environmental_Adapters  &nbsp;  @FraserGreenroyd   
+* Environmental_Adapters  &nbsp;  @FraserGreenroyd & @JamesRamsden-BH  
 * Continuous Integration & Test_Toolkit  &nbsp;  @FraserGreenroyd 
 
 


### PR DESCRIPTION
Fixes #1562

I've done through all our `docs` and `.md` files and updated all references to `master` to be `main`, and updated all links from the GitHub wiki to the `bhom.xyz/documentation` pages instead.

I also updated some of the names in the Governance document while I was there to reflect the current state of affairs 😄  