### PR TITLE
Structure_oM: Added IAreaElements to GeometricalLineloads

### DIFF
--- a/Structure_oM/Loads/GeometricalLineLoad.cs
+++ b/Structure_oM/Loads/GeometricalLineLoad.cs
@@ -64,7 +64,7 @@ namespace BH.oM.Structure.Loads
         public virtual Line Location { get; set; } = null;
 
         [Description("A collection of IAreaElements (e.g. Panels) to apply the line load to. These are not required for all adapters.")]
-        public virtual BHoMGroup<IAreaElement> Objects { get; set; } = null;
+        public virtual BHoMGroup<IAreaElement> Objects { get; set; } = new BHoMGroup<IAreaElement>();
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/GeometricalLineLoad.cs
+++ b/Structure_oM/Loads/GeometricalLineLoad.cs
@@ -24,11 +24,12 @@ using BH.oM.Base;
 using BH.oM.Geometry;
 using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
+using BH.oM.Structure.Elements;
 
 namespace BH.oM.Structure.Loads
 {
     [Description("Distributed load to be applied over a line.")]
-    public class GeometricalLineLoad : BHoMObject, ILoad
+    public class GeometricalLineLoad : BHoMObject, ILoad, IElementLoad<IAreaElement> 
     {
         /***************************************************/
         /****            Public Properties              ****/
@@ -61,6 +62,9 @@ namespace BH.oM.Structure.Loads
 
         [Description("Line defining the location of the load.")]
         public virtual Line Location { get; set; } = null;
+
+        [Description("Group of IAreaElement representing influenced panels.")]
+        public virtual BHoMGroup<IAreaElement> Objects { get; set; } = null;
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/GeometricalLineLoad.cs
+++ b/Structure_oM/Loads/GeometricalLineLoad.cs
@@ -29,7 +29,7 @@ using BH.oM.Structure.Elements;
 namespace BH.oM.Structure.Loads
 {
     [Description("Distributed load to be applied over a line.")]
-    public class GeometricalLineLoad : BHoMObject, ILoad, IElementLoad<IAreaElement> 
+    public class GeometricalLineLoad : BHoMObject, IElementLoad<IAreaElement> 
     {
         /***************************************************/
         /****            Public Properties              ****/
@@ -63,7 +63,7 @@ namespace BH.oM.Structure.Loads
         [Description("Line defining the location of the load.")]
         public virtual Line Location { get; set; } = null;
 
-        [Description("Group of IAreaElement representing influenced panels.")]
+        [Description("A collection of IAreaElements (e.g. Panels) to apply the line load to. These are not required for all adapters.")]
         public virtual BHoMGroup<IAreaElement> Objects { get; set; } = null;
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
A GeometricalLineLoad currently does not have an attribute that represents the object(s) on which it is placed or which should be influenced by it. This PR should add an aditional attribute representing Panels which the GeometricalLineLoad is potentially influencing. 


Closes #1564 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
- [Test File](https://burohappold.sharepoint.com/:u:/s/BHoM/EXjZFLEOqjxLhvPfr06fLusBIcaQr2MyubvPd3PGA3sdkw?e=Li8dN1)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Updated `GeometricalLineLoad` to implement the `IElementLoad<IAreaElement>`;
- Added the 'Objects' attribute to `GeometricalLineLoads`, this will enable the load to be applied to specific `Panel` elements (which is required in some use cases).

### Additional comments
<!-- As required -->