### PR TITLE
Analytical_oM: Rename StartNode/EndNode to Start/Node

### DIFF
--- a/Analytical_oM/Elements/ILink.cs
+++ b/Analytical_oM/Elements/ILink.cs
@@ -37,9 +37,9 @@ namespace BH.oM.Analytical.Elements
         /**** Properties                                ****/
         /***************************************************/
 
-        TNode StartNode { get; set; }
+        TNode Start { get; set; }
 
-        TNode EndNode { get; set; }
+        TNode End { get; set; }
 
         /***************************************************/
     }

--- a/Analytical_oM/Versioning_71.json
+++ b/Analytical_oM/Versioning_71.json
@@ -1,0 +1,40 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Method": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Property": {
+    "ToNew": {
+      "BH.oM.Analytical.Elements.ILink.StartNode": "BH.oM.Analytical.Elements.ILink.Start",
+      "BH.oM.Analytical.Elements.ILink.EndNode": "BH.oM.Analytical.Elements.ILink.End"
+    },
+    "ToOld": {
+      "BH.oM.Analytical.Elements.ILink.Start": "BH.oM.Analytical.Elements.ILink.StartNode",
+      "BH.oM.Analytical.Elements.ILink.End": "BH.oM.Analytical.Elements.ILink.End"
+    }
+  },
+  "MessageForDeleted": {
+    
+  },
+  "MessageForNoUpgrade": {
+
+  }
+}

--- a/Structure_oM/Elements/Bar.cs
+++ b/Structure_oM/Elements/Bar.cs
@@ -46,10 +46,10 @@ namespace BH.oM.Structure.Elements
         /***************************************************/
 
         [Description("Defines the start position of the element. Note that Nodes can contain Supports which should not be confused with Releases.")]
-        public virtual Node StartNode { get; set; }
+        public virtual Node Start { get; set; }
 
         [Description("Defines the end position of the element. Note that Nodes can contain Supports which should not be confused with Releases.")]
-        public virtual Node EndNode { get; set; }
+        public virtual Node End { get; set; }
 
         [Description("Section property of the bar, containing all sectional constants and material as well as profile geometry and dimensions, where applicable.")]
         public virtual ISectionProperty SectionProperty { get; set; } = null;

--- a/Structure_oM/Versioning_71.json
+++ b/Structure_oM/Versioning_71.json
@@ -1,0 +1,40 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Method": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Property": {
+    "ToNew": {
+      "BH.oM.Structure.Elements.Bar.StartNode": "BH.oM.Structure.Elements.Bar.Start",
+      "BH.oM.Structure.Elements.Bar.EndNode": "BH.oM.Structure.Elements.Bar.End"
+    },
+    "ToOld": {
+      "BH.oM.Structure.Elements.Bar.Start": "BH.oM.Structure.Elements.Bar.StartNode",
+      "BH.oM.Structure.Elements.Bar.End": "BH.oM.Structure.Elements.Bar.End"
+    }
+  },
+  "MessageForDeleted": {
+    
+  },
+  "MessageForNoUpgrade": {
+
+  }
+}


### PR DESCRIPTION
Fixes #487 

### Changelog
 - Analytical_oM `ILink` property updated from `StartNode` to `Start` and from `EndNode` to `End`
 - Structure_oM `Bar` object updated accordingly based on Analytical oM interface update