### PR TITLE
Base_oM: add a `UseGeometryHash` option to the `BaseComparisonConfig`

### DIFF
--- a/BHoM/BaseComparisonConfig.cs
+++ b/BHoM/BaseComparisonConfig.cs
@@ -86,10 +86,10 @@ namespace BH.oM.Base
              "\nIf a match is found, this take precedence over the global `SignificantFigures`." +
              "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
         public virtual HashSet<NamedSignificantFigures> PropertySignificantFigures { get; set; } = new HashSet<NamedSignificantFigures>();
+
+        [Description("If true, geometric types will be identified based on the GeometryHash function. " +
+            "This function reduces the identity of geometry down to its most basic components, and it is faster than scouring for all its properties. " +
+            "See its implementation in the Geometry_Engine for more details.")]
+        public virtual bool UseGeometryHash { get; set; } = true;
     }
 }
-
-
-
-
-

--- a/BHoM/BaseComparisonConfig.cs
+++ b/BHoM/BaseComparisonConfig.cs
@@ -23,73 +23,114 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace BH.oM.Base
 {
     [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
-    public abstract class BaseComparisonConfig : IObject
+    public abstract class BaseComparisonConfig : IObject, IImmutable
     {
         [Description("Names of properties you want to disregard in defining the uniqueness of an object. You can specify the property name or the Full Name. Supports * wildcard."
             + "\nExamples of valid values: `BHoM_Guid`, `StartNode`, `Bar.StartNode.Position.X`, `Bar.*.Position.Y`. See the wiki for more details.")]
-        public virtual List<string> PropertyExceptions { get; set; } = new List<string>() { };
+        public virtual HashSet<string> PropertyExceptions { get; } = new HashSet<string>() { };
 
         [Description("If one or more entries are specified here, only objects/properties that match them will be considered in the hash." +
            "\nE.g. Given input objects BH.oM.Structure.Elements.Bar, specifying `StartNode` will only check that property of the Bar." +
            "\nLike for PropertyExceptions, you can specify the property name or the Full Name. Supports * wildcard." +
            "\nNote that using this will incur in a general slowdown because it is computationally heavy. See the wiki for more details.")]
-        public virtual List<string> PropertiesToConsider { get; set; } = new List<string>();
+        public virtual HashSet<string> PropertiesToConsider { get; } = new HashSet<string>();
 
         [Description("Keys of the BHoMObjects' CustomData dictionary that should be ignored." +
             "\nBy default it includes `RenderMesh`. " +
             "\nThis does not support wildcard usage. See the wiki for more details.")]
-        public virtual List<string> CustomdataKeysExceptions { get; set; } = new List<string>() { "RenderMesh" };
+        public virtual HashSet<string> CustomdataKeysExceptions { get; } = new HashSet<string>() { "RenderMesh" };
 
         [Description("Keys of the BHoMObjects' CustomData dictionary that should be included in the comparison." +
             "\nAdding keys to this List will exclude any key that is not in this List." +
             "\nI.e. for every object, if it has CustomData keys present in this List, we then exclude any other CustomData key found in it.")]
-        public virtual List<string> CustomdataKeysToConsider { get; set; } = new List<string>() { };
+        public virtual HashSet<string> CustomdataKeysToConsider { get; } = new HashSet<string>() { };
 
         [Description("Any corresponding type is ignored. E.g. `typeof(Guid)`.")]
-        public virtual List<Type> TypeExceptions { get; set; } = new List<Type>();
+        public virtual HashSet<Type> TypeExceptions { get; } = new HashSet<Type>();
 
         [Description("Any corresponding namespace is ignored. E.g. `BH.oM.Structure`. Does not support wildcard. See the wiki for more details.")]
-        public virtual List<string> NamespaceExceptions { get; set; } = new List<string>();
+        public virtual HashSet<string> NamespaceExceptions { get; } = new HashSet<string>();
 
         [Description("If any property is nested into the object over that level, it is ignored. Useful to limit the runtime." +
             "\nDefaults to unlimited.")]
-        public virtual int MaxNesting { get; set; } = int.MaxValue;
+        public virtual int MaxNesting { get; } = int.MaxValue;
 
         [Description("Sets the maximum number of property differences to be determined before stopping. Useful to limit the runtime." +
             "\nDefaults to unlimited.")]
-        public virtual int MaxPropertyDifferences { get; set; } = int.MaxValue;
+        public virtual int MaxPropertyDifferences { get; } = int.MaxValue;
 
         [Description("Numeric tolerance for property values, applied to all numerical properties. Defaults to double.MinValue: no rounding applied." +
             "\nApplies rounding for numbers smaller than this." +
             "\nYou can override on a per-property basis by using `PropertyNumericTolerances`." +
             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual double NumericTolerance { get; set; } = double.MinValue;
+        public virtual double NumericTolerance { get; } = double.MinValue;
 
         [Description("Tolerance used for individual properties. When computing Hash or the property Diffing, if the analysed property name is found in this collection, the corresponding tolerance is applied." +
             "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
             "\nIf a match is found, this take precedence over the global `NumericTolerance`." +
             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual HashSet<NamedNumericTolerance> PropertyNumericTolerances { get; set; } = new HashSet<NamedNumericTolerance>();
+        public virtual HashSet<NamedNumericTolerance> PropertyNumericTolerances { get; } = new HashSet<NamedNumericTolerance>();
 
         [Description("Number of significant figures allowed for numerical data." +
             "\nDefaults to `int.MaxValue`: no approximation applied." +
             "\nYou can override on a per-property basis by using `PropertySignificantDigits`." +
             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual int SignificantFigures { get; set; } = int.MaxValue;
+        public virtual int SignificantFigures { get; } = int.MaxValue;
 
         [Description("Number of significant figures allowed for numerical data on a per-property base. " +
              "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
              "\nIf a match is found, this take precedence over the global `SignificantFigures`." +
              "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual HashSet<NamedSignificantFigures> PropertySignificantFigures { get; set; } = new HashSet<NamedSignificantFigures>();
+        public virtual HashSet<NamedSignificantFigures> PropertySignificantFigures { get; } = new HashSet<NamedSignificantFigures>();
 
         [Description("If true, geometric types will be identified based on the GeometryHash function. " +
             "This function reduces the identity of geometry down to its most basic components, and it is faster than scouring for all its properties. " +
             "See its implementation in the Geometry_Engine for more details.")]
-        public virtual bool UseGeometryHash { get; set; } = true;
+        public virtual bool UseGeometryHash { get; } = true;
+
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public BaseComparisonConfig(HashSet<string> propertyExceptions = null, HashSet<string> propertiesToConsider = null,
+            HashSet<string> customdataKeysExceptions = null, HashSet<string> customdataKeysToConsider = null,
+            HashSet<Type> typeExceptions = null, HashSet<string> namespaceExceptions = null,
+            int maxNesting = int.MaxValue, int maxPropertyDifferences = int.MaxValue,
+            double numericTolerance = double.MinValue, HashSet<NamedNumericTolerance> propertyNumericTolerances = null,
+            int significantFigures = int.MaxValue, HashSet<NamedSignificantFigures> propertySignificantFigures = null,
+            bool useGeometryHash = false)
+        {
+            PropertyExceptions = propertyExceptions ?? new HashSet<string>();
+            PropertiesToConsider = propertiesToConsider ?? new HashSet<string>();
+            CustomdataKeysExceptions = customdataKeysExceptions ?? new HashSet<string>();
+            CustomdataKeysToConsider = customdataKeysToConsider ?? new HashSet<string>();
+            TypeExceptions = typeExceptions ?? new HashSet<Type>();
+            NamespaceExceptions = namespaceExceptions ?? new HashSet<string>();
+            MaxNesting = maxNesting < 0 ? int.MaxValue : maxNesting;
+            MaxPropertyDifferences = maxPropertyDifferences < 0 ? int.MaxValue : maxPropertyDifferences;
+            NumericTolerance = Math.Abs(numericTolerance);
+            PropertyNumericTolerances = propertyNumericTolerances ?? new HashSet<NamedNumericTolerance>();
+            SignificantFigures = Math.Abs(significantFigures);
+            PropertySignificantFigures = propertySignificantFigures ?? new HashSet<NamedSignificantFigures>();
+            UseGeometryHash = useGeometryHash;
+
+            if (!UseGeometryHash)
+                return;
+
+            // Verify that no numerical approximation is requested for objects belonging to Geometrical types.
+            if (PropertyNumericTolerances?.Where(p => p.Name.Contains("Geometry")).Any() ?? false)
+                throw new ArgumentException($"Please note that the input {nameof(ComparisonConfig)}.{nameof(PropertyNumericTolerances)} will not be considered for Geometry objects because {nameof(UseGeometryHash)} was set to true.");
+
+            if (PropertySignificantFigures?.Where(p => p.Name.Contains("Geometry")).Any() ?? false)
+                throw new ArgumentException($"Please note that the input {nameof(ComparisonConfig)}.{nameof(PropertySignificantFigures)} will not be considered for Geometry objects because {nameof(UseGeometryHash)} was set to true.");
+        }
+
+        /***************************************************/
     }
 }

--- a/BHoM/BaseComparisonConfig.cs
+++ b/BHoM/BaseComparisonConfig.cs
@@ -23,114 +23,73 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 
 namespace BH.oM.Base
 {
     [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
-    public abstract class BaseComparisonConfig : IObject, IImmutable
+    public abstract class BaseComparisonConfig : IObject
     {
         [Description("Names of properties you want to disregard in defining the uniqueness of an object. You can specify the property name or the Full Name. Supports * wildcard."
             + "\nExamples of valid values: `BHoM_Guid`, `StartNode`, `Bar.StartNode.Position.X`, `Bar.*.Position.Y`. See the wiki for more details.")]
-        public virtual HashSet<string> PropertyExceptions { get; } = new HashSet<string>() { };
+        public virtual List<string> PropertyExceptions { get; set; } = new List<string>() { };
 
         [Description("If one or more entries are specified here, only objects/properties that match them will be considered in the hash." +
            "\nE.g. Given input objects BH.oM.Structure.Elements.Bar, specifying `StartNode` will only check that property of the Bar." +
            "\nLike for PropertyExceptions, you can specify the property name or the Full Name. Supports * wildcard." +
            "\nNote that using this will incur in a general slowdown because it is computationally heavy. See the wiki for more details.")]
-        public virtual HashSet<string> PropertiesToConsider { get; } = new HashSet<string>();
+        public virtual List<string> PropertiesToConsider { get; set; } = new List<string>();
 
         [Description("Keys of the BHoMObjects' CustomData dictionary that should be ignored." +
             "\nBy default it includes `RenderMesh`. " +
             "\nThis does not support wildcard usage. See the wiki for more details.")]
-        public virtual HashSet<string> CustomdataKeysExceptions { get; } = new HashSet<string>() { "RenderMesh" };
+        public virtual List<string> CustomdataKeysExceptions { get; set; } = new List<string>() { "RenderMesh" };
 
         [Description("Keys of the BHoMObjects' CustomData dictionary that should be included in the comparison." +
             "\nAdding keys to this List will exclude any key that is not in this List." +
             "\nI.e. for every object, if it has CustomData keys present in this List, we then exclude any other CustomData key found in it.")]
-        public virtual HashSet<string> CustomdataKeysToConsider { get; } = new HashSet<string>() { };
+        public virtual List<string> CustomdataKeysToConsider { get; set; } = new List<string>() { };
 
         [Description("Any corresponding type is ignored. E.g. `typeof(Guid)`.")]
-        public virtual HashSet<Type> TypeExceptions { get; } = new HashSet<Type>();
+        public virtual List<Type> TypeExceptions { get; set; } = new List<Type>();
 
         [Description("Any corresponding namespace is ignored. E.g. `BH.oM.Structure`. Does not support wildcard. See the wiki for more details.")]
-        public virtual HashSet<string> NamespaceExceptions { get; } = new HashSet<string>();
+        public virtual List<string> NamespaceExceptions { get; set; } = new List<string>();
 
         [Description("If any property is nested into the object over that level, it is ignored. Useful to limit the runtime." +
             "\nDefaults to unlimited.")]
-        public virtual int MaxNesting { get; } = int.MaxValue;
+        public virtual int MaxNesting { get; set; } = int.MaxValue;
 
         [Description("Sets the maximum number of property differences to be determined before stopping. Useful to limit the runtime." +
             "\nDefaults to unlimited.")]
-        public virtual int MaxPropertyDifferences { get; } = int.MaxValue;
+        public virtual int MaxPropertyDifferences { get; set; } = int.MaxValue;
 
         [Description("Numeric tolerance for property values, applied to all numerical properties. Defaults to double.MinValue: no rounding applied." +
             "\nApplies rounding for numbers smaller than this." +
             "\nYou can override on a per-property basis by using `PropertyNumericTolerances`." +
             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual double NumericTolerance { get; } = double.MinValue;
+        public virtual double NumericTolerance { get; set; } = double.MinValue;
 
         [Description("Tolerance used for individual properties. When computing Hash or the property Diffing, if the analysed property name is found in this collection, the corresponding tolerance is applied." +
             "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
             "\nIf a match is found, this take precedence over the global `NumericTolerance`." +
             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual HashSet<NamedNumericTolerance> PropertyNumericTolerances { get; } = new HashSet<NamedNumericTolerance>();
+        public virtual HashSet<NamedNumericTolerance> PropertyNumericTolerances { get; set; } = new HashSet<NamedNumericTolerance>();
 
         [Description("Number of significant figures allowed for numerical data." +
             "\nDefaults to `int.MaxValue`: no approximation applied." +
             "\nYou can override on a per-property basis by using `PropertySignificantDigits`." +
             "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual int SignificantFigures { get; } = int.MaxValue;
+        public virtual int SignificantFigures { get; set; } = int.MaxValue;
 
         [Description("Number of significant figures allowed for numerical data on a per-property base. " +
              "\nSupports * wildcard in the property name matching. E.g. `StartNode.Point.*, 2`." +
              "\nIf a match is found, this take precedence over the global `SignificantFigures`." +
              "\nIf conflicting values/multiple matches are found among the Configurations on numerical precision, the largest approximation among all (least precise number) is registered.")]
-        public virtual HashSet<NamedSignificantFigures> PropertySignificantFigures { get; } = new HashSet<NamedSignificantFigures>();
+        public virtual HashSet<NamedSignificantFigures> PropertySignificantFigures { get; set; } = new HashSet<NamedSignificantFigures>();
 
         [Description("If true, geometric types will be identified based on the GeometryHash function. " +
             "This function reduces the identity of geometry down to its most basic components, and it is faster than scouring for all its properties. " +
             "See its implementation in the Geometry_Engine for more details.")]
-        public virtual bool UseGeometryHash { get; } = true;
-
-
-        /***************************************************/
-        /**** Constructors                              ****/
-        /***************************************************/
-
-        public BaseComparisonConfig(HashSet<string> propertyExceptions = null, HashSet<string> propertiesToConsider = null,
-            HashSet<string> customdataKeysExceptions = null, HashSet<string> customdataKeysToConsider = null,
-            HashSet<Type> typeExceptions = null, HashSet<string> namespaceExceptions = null,
-            int maxNesting = int.MaxValue, int maxPropertyDifferences = int.MaxValue,
-            double numericTolerance = double.MinValue, HashSet<NamedNumericTolerance> propertyNumericTolerances = null,
-            int significantFigures = int.MaxValue, HashSet<NamedSignificantFigures> propertySignificantFigures = null,
-            bool useGeometryHash = false)
-        {
-            PropertyExceptions = propertyExceptions ?? new HashSet<string>();
-            PropertiesToConsider = propertiesToConsider ?? new HashSet<string>();
-            CustomdataKeysExceptions = customdataKeysExceptions ?? new HashSet<string>();
-            CustomdataKeysToConsider = customdataKeysToConsider ?? new HashSet<string>();
-            TypeExceptions = typeExceptions ?? new HashSet<Type>();
-            NamespaceExceptions = namespaceExceptions ?? new HashSet<string>();
-            MaxNesting = maxNesting < 0 ? int.MaxValue : maxNesting;
-            MaxPropertyDifferences = maxPropertyDifferences < 0 ? int.MaxValue : maxPropertyDifferences;
-            NumericTolerance = Math.Abs(numericTolerance);
-            PropertyNumericTolerances = propertyNumericTolerances ?? new HashSet<NamedNumericTolerance>();
-            SignificantFigures = Math.Abs(significantFigures);
-            PropertySignificantFigures = propertySignificantFigures ?? new HashSet<NamedSignificantFigures>();
-            UseGeometryHash = useGeometryHash;
-
-            if (!UseGeometryHash)
-                return;
-
-            // Verify that no numerical approximation is requested for objects belonging to Geometrical types.
-            if (PropertyNumericTolerances?.Where(p => p.Name.Contains("Geometry")).Any() ?? false)
-                throw new ArgumentException($"Please note that the input {nameof(ComparisonConfig)}.{nameof(PropertyNumericTolerances)} will not be considered for Geometry objects because {nameof(UseGeometryHash)} was set to true.");
-
-            if (PropertySignificantFigures?.Where(p => p.Name.Contains("Geometry")).Any() ?? false)
-                throw new ArgumentException($"Please note that the input {nameof(ComparisonConfig)}.{nameof(PropertySignificantFigures)} will not be considered for Geometry objects because {nameof(UseGeometryHash)} was set to true.");
-        }
-
-        /***************************************************/
+        public virtual bool UseGeometryHash { get; set; } = true;
     }
 }

--- a/BHoM/ComparisonConfig.cs
+++ b/BHoM/ComparisonConfig.cs
@@ -29,21 +29,10 @@ namespace BH.oM.Base
     [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
     public class ComparisonConfig : BaseComparisonConfig
     {
-        public ComparisonConfig(HashSet<string> propertyExceptions = null, HashSet<string> propertiesToConsider = null,
-            HashSet<string> customdataKeysExceptions = null, HashSet<string> customdataKeysToConsider = null,
-            HashSet<Type> typeExceptions = null, HashSet<string> namespaceExceptions = null,
-            int maxNesting = int.MaxValue, int maxPropertyDifferences = int.MaxValue,
-            double numericTolerance = double.MinValue, HashSet<NamedNumericTolerance> propertyNumericTolerances = null,
-            int significantFigures = int.MaxValue, HashSet<NamedSignificantFigures> propertySignificantFigures = null,
-            bool useGeometryHash = false) : base(propertyExceptions, propertiesToConsider,
-                customdataKeysExceptions, customdataKeysToConsider,
-                typeExceptions, namespaceExceptions,
-                maxNesting, maxPropertyDifferences,
-                numericTolerance, propertyNumericTolerances,
-                significantFigures, propertySignificantFigures,
-                useGeometryHash)
-        {
-
-        }
     }
 }
+
+
+
+
+

--- a/BHoM/ComparisonConfig.cs
+++ b/BHoM/ComparisonConfig.cs
@@ -29,10 +29,21 @@ namespace BH.oM.Base
     [Description("Settings to determine the uniqueness of an Object, i.e. when comparing and when computing the object Hash.")]
     public class ComparisonConfig : BaseComparisonConfig
     {
+        public ComparisonConfig(HashSet<string> propertyExceptions = null, HashSet<string> propertiesToConsider = null,
+            HashSet<string> customdataKeysExceptions = null, HashSet<string> customdataKeysToConsider = null,
+            HashSet<Type> typeExceptions = null, HashSet<string> namespaceExceptions = null,
+            int maxNesting = int.MaxValue, int maxPropertyDifferences = int.MaxValue,
+            double numericTolerance = double.MinValue, HashSet<NamedNumericTolerance> propertyNumericTolerances = null,
+            int significantFigures = int.MaxValue, HashSet<NamedSignificantFigures> propertySignificantFigures = null,
+            bool useGeometryHash = false) : base(propertyExceptions, propertiesToConsider,
+                customdataKeysExceptions, customdataKeysToConsider,
+                typeExceptions, namespaceExceptions,
+                maxNesting, maxPropertyDifferences,
+                numericTolerance, propertyNumericTolerances,
+                significantFigures, propertySignificantFigures,
+                useGeometryHash)
+        {
+
+        }
     }
 }
-
-
-
-
-


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1587 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/BHoM_Engine/pull/3268

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->