### PR TITLE
BHoM: Promote IInitialisationSettings interface from UI_oM

### DIFF
--- a/BHoM/Interface/IInitialisationSettings.cs
+++ b/BHoM/Interface/IInitialisationSettings.cs
@@ -29,7 +29,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.UI
+namespace BH.oM.Base
 {
     [Description("Toolkit Settings that contain an initialisation method to be ran when the UI starts.")]
     public interface IInitialisationSettings : IImmutable

--- a/BHoM/Interface/IInitialisationSettings.cs
+++ b/BHoM/Interface/IInitialisationSettings.cs
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.UI
+{
+    [Description("Toolkit Settings that contain an initialisation method to be ran when the UI starts.")]
+    public interface IInitialisationSettings : IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        string InitialisationMethod { get; }
+
+        /***************************************************/
+    }
+}
+
+
+
+
+

--- a/BHoM/UsageLogEntry.cs
+++ b/BHoM/UsageLogEntry.cs
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Base.Debugging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Base
+{
+    public class UsageLogEntry : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual DateTime Time { get; set; } = DateTime.UtcNow;
+
+        public virtual string UI { get; set; } = "";
+
+        public virtual string UiVersion { get; set; } = "";
+
+        public virtual string BHoMVersion { get; set; } = "";
+
+        public virtual Guid ComponentId { get; set; } = Guid.Empty;
+
+        public virtual string CallerName { get; set; } = "";
+
+        public virtual object SelectedItem { get; set; } = null;
+
+        public virtual string FileId { get; set; } = "";
+
+        public virtual string FileName { get; set; } = "";
+
+        public virtual string ProjectID { get; set; } = "";
+
+        public virtual List<Event> Errors { get; set; } = new List<Event>();
+
+
+        /***************************************************/
+    }
+}
+
+
+
+
+

--- a/BHoM/Versioning_71.json
+++ b/BHoM/Versioning_71.json
@@ -1,10 +1,12 @@
 {
   "Type": {
     "ToNew": {
-       "BH.oM.UI.IInitialisationSettings" :  "BH.oM.Base.IInitialisationSettings"
+      "BH.oM.UI.IInitialisationSettings": "BH.oM.Base.IInitialisationSettings",
+      "BH.oM.UI.UsageLogEntry" :  "BH.oM.Base.UsageLogEntry"
     },
     "ToOld": {
-      "BH.oM.Base.IInitialisationSettings": "BH.oM.UI.IInitialisationSettings"
+      "BH.oM.Base.IInitialisationSettings": "BH.oM.UI.IInitialisationSettings",
+      "BH.oM.Base.UsageLogEntry": "BH.oM.UI.UsageLogEntry"
     }
   },
   "MessageForDeleted": {

--- a/BHoM/Versioning_71.json
+++ b/BHoM/Versioning_71.json
@@ -1,4 +1,12 @@
 {
+  "Type": {
+    "ToNew": {
+       "BH.oM.UI.IInitialisationSettings" :  "BH.oM.Base.IInitialisationSettings"
+    },
+    "ToOld": {
+      "BH.oM.Base.IInitialisationSettings": "BH.oM.UI.IInitialisationSettings"
+    }
+  },
   "MessageForDeleted": {
     "BH.oM.Base.Attributes.AssemblyUrlAttribute": "This attribute has been removed as a part of legacy cleanup. Please contact developers in case you still need it.",
     "BH.oM.Base.Attributes.ReleasedAttribute": "This attribute has been removed as a part of legacy cleanup. Please contact developers in case you still need it."


### PR DESCRIPTION
Fixes https://github.com/BHoM/BHoMAnalytics_Toolkit/issues/73

Promotes up `IInitialisationSettings` interface from UI_oM to Base_oM. This then removes the need for BHoMAnalytics_Toolkit to depend on BHoM_UI, which in turn removes the need for BHoM_UI to be a nuget and removes the warning/error raised from the zero code tools @adecler is working on when using BHoMAnalytics_Toolkit nuget but the `NetFramework` version of BHoM_UI is incompatible.