### PR TITLE
Structure_oM: Update Timber Material to be inherit ITimber

### DIFF
--- a/Structure_oM/MaterialFragments/Timber.cs
+++ b/Structure_oM/MaterialFragments/Timber.cs
@@ -28,7 +28,7 @@ using BH.oM.Geometry;
 namespace BH.oM.Structure.MaterialFragments
 {
     [Description("Structural timber material to be used on structural elements and properties or as a fragment of the physical material.")]
-    public class Timber : BHoMObject, IOrthotropic
+    public class Timber : BHoMObject, ITimber
     {
         /***************************************************/
         /**** Properties                                ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1518 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Test script](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/BHoM/Structure_oM/%231518-UpdateTimberToITimber.gh?csf=1&web=1&e=oFcHfa)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Updated `Timber` material to inherit the `ITimber` interface;

### Additional comments
<!-- As required -->
This will fix the issue of using the following datasets Structure\Materials\MaterialsEurope\SawnTimber
Structure\Materials\MaterialsEurope\Glulam with the `Create` methods for a `TimberSection`.