### PR TITLE
Ground_oM: Changes to ContaminantSample and ResultProperties

### DIFF
--- a/Ground_oM/ContaminantProperties/ResultProperties.cs
+++ b/Ground_oM/ContaminantProperties/ResultProperties.cs
@@ -39,6 +39,9 @@ namespace BH.oM.Ground
         [Description("The result type for the contaminant sample (ERES_RTCD).")]
         public virtual string Type { get; set; } = "";
 
+        [Description("The interepreted qualifier that shows whether a Result was lower than a detection threshold (ERES_IQLF).")]
+        public virtual string Qualifier { get; set; } = "";
+
         [Description("Is the result reportable (ERES_RRES).")]
         public virtual bool Reportable { get; set; } = false;
 

--- a/Ground_oM/ContaminantSample.cs
+++ b/Ground_oM/ContaminantSample.cs
@@ -30,6 +30,7 @@ using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Quantities.Attributes;
 using BH.oM.Base.Attributes;
 using BH.oM.Base.Attributes.Enums;
+using System;
 
 namespace BH.oM.Ground
 {
@@ -51,11 +52,14 @@ namespace BH.oM.Ground
         public virtual string Chemical { get; set; }
 
         [MassFraction]
-        [Description("The amount of the chemical present (ERES_RVAL).")]
+        [Description("The amount of the chemical present (ERES_RTXT).")]
         public virtual double Result { get; set; }
 
         [Description("The type of sample (SAMP_TYPE).")]
         public virtual string Type { get; set; }
+
+        [Description("The quantity of the Result as a QuantityType such as Concentration, Molality, Molarity.")]
+        public virtual Type ResultQuantity { get; set; }
 
         [Description("A list of different properties including references, tests, analysis, results and detection.")]
         public virtual List<IContaminantProperty> ContaminantProperties { get; set; }

--- a/Quantities_oM/Attributes/ElectricConductance.cs
+++ b/Quantities_oM/Attributes/ElectricConductance.cs
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+
+namespace BH.oM.Quantities.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ElectricConductance : QuantityAttribute
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public override int M { get; } = -1;
+
+        public override int L { get; } = -2;
+
+        public override int T { get; } = 3;
+
+        public override int I { get; } = 2;
+
+        public override string SIUnit { get; } = "S";
+
+        /***************************************************/
+    }
+}
+
+
+
+
+

--- a/Quantities_oM/Attributes/Molality.cs
+++ b/Quantities_oM/Attributes/Molality.cs
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+
+namespace BH.oM.Quantities.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class Molality : QuantityAttribute
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public override string SIUnit { get; } = "mol/kg";
+
+        /***************************************************/
+    }
+}
+
+
+
+
+

--- a/Quantities_oM/Attributes/Molarity.cs
+++ b/Quantities_oM/Attributes/Molarity.cs
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+
+namespace BH.oM.Quantities.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class Molarity : QuantityAttribute
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public override int M { get; } = 1;
+
+        public override int L { get; } = -3;
+
+        public override string SIUnit { get; } = "mol/m³";
+
+        /***************************************************/
+    }
+}
+
+
+
+
+


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1622 
Closes #1623 
Closes #1625 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added `ResultQuantity` property to `ContaminantSample to identify the quantity (e.g.`MassFraction`, `Molality` of the `Result`;
- Added additional `Quantity` types to the `Quantity_oM` including `Molarity`, `Molality` and `ElectricConductance`;
- Added `InterpreteredQualifier` property to the `ResultProperties` object (stored on the `ContaminantSample` to include information whether the `Result` is below the level of detection (ERES_IQLF);

### Additional comments
<!-- As required -->