### PR TITLE
Quantities_oM: Add ElectricConductivity

### DIFF
--- a/Quantities_oM/Attributes/ElectricConductivity.cs
+++ b/Quantities_oM/Attributes/ElectricConductivity.cs
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+
+namespace BH.oM.Quantities.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ElectricConductivity : QuantityAttribute
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public override int M { get; } = -1;
+
+        public override int L { get; } = -3;
+
+        public override int T { get; } = 3;
+
+        public override int I { get; } = 2;
+
+        public override string SIUnit { get; } = "S/m";
+
+        /***************************************************/
+    }
+}
+
+
+
+
+
+


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1662 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Add quantity for `ElectricConductivity`

### Additional comments
<!-- As required -->
I have used `Electric` prefix to match `Current` and the convention used on UnitsNet.