### PR TITLE
LifeCycleAssessment_oM: Add support for A5

### DIFF
--- a/LifeCycleAssessment_oM/Configs/GlobalEmissionFactors.cs
+++ b/LifeCycleAssessment_oM/Configs/GlobalEmissionFactors.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using BH.oM.LifeCycleAssessment.MaterialFragments.Construction;
 using BH.oM.Quantities.Attributes;
 using System;

--- a/LifeCycleAssessment_oM/Configs/GlobalEmissionFactors.cs
+++ b/LifeCycleAssessment_oM/Configs/GlobalEmissionFactors.cs
@@ -1,0 +1,26 @@
+﻿using BH.oM.Base;
+using BH.oM.LifeCycleAssessment.MaterialFragments.Construction;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.Configs
+{
+    public class GlobalEmissionFactors : BHoMObject, IEvaluationConfig
+    {
+        [Description("The demolition activities associated with the pre-construction process, which will increase the emissions associated with the construction phase of the building lifecycle. The impact on the final element will be scaled according to its part of the total mass of the building.")]
+        public virtual PreConstructionDemolition PreConstructionDemolition { get; set; } = null;
+
+        [Description("The construction activities associated with the construction process, which will increase the emissions associated with the construction phase of the building lifecycle. The impact on the final element will be scaled according to its part of the total mass of the building.")]
+        public virtual ConstructionActivities ConstructionActivities { get; set; } = null;
+
+        [Mass]
+        [Description("The total mass of the building. When evaluating an element, its part impact for pre-construction demolition as well as site activities will be scaled by this factor.")]
+        public virtual double TotalBuildingMass { get; set; }
+
+        [Description("Boolean that indicates if the provided mass is only the mass of the structure (true) or the total mass of the building including non-structural elements (false). This is relevant for scaling the pre-construction demolition and construction activities emissions which are provided per unit area.")]
+        public virtual bool StructuresOnlyMass { get; set; } = false;
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/CombinedLifeCycleAssessmentFactors.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/CombinedLifeCycleAssessmentFactors.cs
@@ -46,7 +46,7 @@ namespace BH.oM.LifeCycleAssessment.MaterialFragments
         public virtual ITransportFactors A4TransportFactors { get; set; }
 
         [Description("Factors for computing the emissions relating to the Construction and instalation process (A5).")]
-        public virtual ConstructionEmissions A5ConstructionEmissions { get; set; }
+        public virtual ConstructionWasteEmissions A5_3ConstructionWasteEmissions { get; set; }
 
         [Description("Factors for computing the emissions relating to Module C2. Module C2 Transport impacts consists of any carbon impacts associated with the transportation of material from deconstruction and demolition to the appropriate final location, including any interim stations.")]
         public virtual ITransportFactors C2TransportFactors { get; set; }

--- a/LifeCycleAssessment_oM/MaterialFragments/CombinedLifeCycleAssessmentFactors.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/CombinedLifeCycleAssessmentFactors.cs
@@ -21,8 +21,10 @@
  */
 
 using BH.oM.Base;
+using BH.oM.LifeCycleAssessment.MaterialFragments.Construction;
 using BH.oM.LifeCycleAssessment.MaterialFragments.Transport;
 using BH.oM.Physical.Materials;
+using BH.oM.Quantities.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -42,8 +44,12 @@ namespace BH.oM.LifeCycleAssessment.MaterialFragments
         [Description("Factors for computing the emissions relating to Module A4 which captures the impacts associated with the transportation of the materials and components from the factory gate to and from the project site.")]
         public virtual ITransportFactors A4TransportFactors { get; set; }
 
+        [Description("Factors for computing the emissions relating to the Construction and instalation process (A5).")]
+        public virtual ConstructionEmissions A5ConstructionEmissions { get; set; }
+
         [Description("Factors for computing the emissions relating to Module C2. Module C2 Transport impacts consists of any carbon impacts associated with the transportation of material from deconstruction and demolition to the appropriate final location, including any interim stations.")]
         public virtual ITransportFactors C2TransportFactors { get; set; }
+
 
         /***************************************************/
         /**** Explicit Casting                          ****/

--- a/LifeCycleAssessment_oM/MaterialFragments/CombinedLifeCycleAssessmentFactors.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/CombinedLifeCycleAssessmentFactors.cs
@@ -22,6 +22,7 @@
 
 using BH.oM.Base;
 using BH.oM.LifeCycleAssessment.MaterialFragments.Construction;
+using BH.oM.LifeCycleAssessment.MaterialFragments.EndOfLife;
 using BH.oM.LifeCycleAssessment.MaterialFragments.Transport;
 using BH.oM.Physical.Materials;
 using BH.oM.Quantities.Attributes;
@@ -50,6 +51,8 @@ namespace BH.oM.LifeCycleAssessment.MaterialFragments
         [Description("Factors for computing the emissions relating to Module C2. Module C2 Transport impacts consists of any carbon impacts associated with the transportation of material from deconstruction and demolition to the appropriate final location, including any interim stations.")]
         public virtual ITransportFactors C2TransportFactors { get; set; }
 
+        [Description("Factors for computing the emissions relating to Module C3 (waste processing) and C4 (disposal). WasteAndDisposalFactors defines the end of life waste processing and disposal factors to be applied to the material fragment. These factors are applied in addition to any end of life factors provided by an Environmental Product Declaration, and can be used to fill gaps where no EPD data is available. If applied this will help populate all Climate change metrics available, with LandUseFactor being set to 0.")]
+        public virtual WasteAndDisposalFactors C3C4WasteAndDisposalFactors { get; set; }
 
         /***************************************************/
         /**** Explicit Casting                          ****/

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionActivities.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionActivities.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using BH.oM.Quantities.Attributes;
 using System;
 using System.Collections.Generic;

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionActivities.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionActivities.cs
@@ -1,0 +1,26 @@
+﻿using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.MaterialFragments.Construction
+{
+    [Description("A class defining the environmental impacts associated with the construction activities of a building.")]
+    public class ConstructionActivities : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("List of environmental factors associated with the construction process. The default values are indicative only and should be replaced with project specific data where available. All factors stated per unit area.")]
+        public virtual List<IEnvironmentalFactor> EnvironmentalFactors { get; set; } = new List<IEnvironmentalFactor>() { new ClimateChangeFossilFactor { Value = 40 }, new ClimateChangeBiogenicFactor { Value = 0 }, new ClimateChangeLandUseFactor { Value = 0 }, new ClimateChangeTotalFactor { Value = 40 }, new ClimateChangeTotalNoBiogenicFactor { Value = 40 } };
+
+        [Area]
+        [Description("The total gross internal area (GIA) of the constructed building. This is used to scale the environmental factors above.")]
+        public virtual double ConstructedFloorArea { get; set; } = 0;
+
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionEmissions.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionEmissions.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionEmissions.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionEmissions.cs
@@ -1,0 +1,24 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.MaterialFragments.Construction
+{
+    [Description("ConstructionEmissions defines the emissions associated with the construction phase of the building lifecycle, including pre-construction demolition activities, construction activities, waste rates and whether the material is reused on site.")]
+    public class ConstructionEmissions : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("The waste rate associated with the construction process, which will increase the amount of material required to be ordered and processed to account for waste. This factor is used to compute A5.3 emissions based on outputs available from either EPD and/or transport as well as disposal factors.")]
+        public virtual WasteRate WasteRate { get; set; } = null;
+
+        [Description("Whether the material is reused on site, which would reduce the emissions associated with transport and processing. Controls wether the C2 factor for the material should be included or not when computing the emissions based on the A5.3 (waste) factor. Defaults to false, meaning the C2 factor is included.")]
+        public virtual bool ResuedOnSite { get; set; } = false;
+
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionWasteEmissions.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionWasteEmissions.cs
@@ -35,10 +35,11 @@ namespace BH.oM.LifeCycleAssessment.MaterialFragments.Construction
         /**** Properties                                ****/
         /***************************************************/
 
-        [Description("The waste rate associated with the construction process, which will increase the amount of material required to be ordered and processed to account for waste. This factor is used to compute A5.3 emissions based on outputs available from either EPD and/or transport as well as disposal factors.")]
+        [Description("The waste rate associated with the construction process. This factor is used to compute A5.3 emissions based on outputs for A1 to A4 and C2 to C4 available from either EPD and/or transport as well as disposal factors.\n" +
+                     "This value should be the percentage of material brought to site that goes to waste. This is turned into a waste factor to allow for evaluating based on quantities of the built asset.")]
         public virtual WasteRate WasteRate { get; set; } = null;
 
-        [Description("Whether the material is reused on site, which would reduce the emissions associated with transport and processing. Controls wether the C2 factor for the material should be included or not when computing the emissions based on the A5.3 (waste) factor. Defaults to false, meaning the C2 factor is included.")]
+        [Description("Whether the material is reused on site, which would reduce the emissions associated with transport and processing. Controls whether the C2 factor for the material should be included or not when computing the emissions based on the A5.3 (waste) factor. Defaults to false, meaning the C2 factor is included.")]
         public virtual bool ResuedOnSite { get; set; } = false;
 
         /***************************************************/

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionWasteEmissions.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionWasteEmissions.cs
@@ -29,7 +29,7 @@ using System.Text;
 namespace BH.oM.LifeCycleAssessment.MaterialFragments.Construction
 {
     [Description("ConstructionEmissions defines the emissions associated with the construction phase of the building lifecycle, including pre-construction demolition activities, construction activities, waste rates and whether the material is reused on site.")]
-    public class ConstructionEmissions : BHoMObject
+    public class ConstructionWasteEmissions : BHoMObject
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionWasteEmissions.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/ConstructionWasteEmissions.cs
@@ -28,7 +28,7 @@ using System.Text;
 
 namespace BH.oM.LifeCycleAssessment.MaterialFragments.Construction
 {
-    [Description("ConstructionEmissions defines the emissions associated with the construction phase of the building lifecycle, including pre-construction demolition activities, construction activities, waste rates and whether the material is reused on site.")]
+    [Description("Production, transportation, storage and end-of-life treatment and disposal of any material/waste on-site: transport, waste management and disposal of packaging materials.")]
     public class ConstructionWasteEmissions : BHoMObject
     {
         /***************************************************/

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/PreConstructionDemolition.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/PreConstructionDemolition.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using BH.oM.Quantities.Attributes;
 using System;
 using System.Collections.Generic;

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/PreConstructionDemolition.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/PreConstructionDemolition.cs
@@ -1,0 +1,26 @@
+﻿using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.MaterialFragments.Construction
+{
+    [Description("A class defining the environmental impacts associated with the demolition of existing buildings prior to construction of a new building.")]
+    public class PreConstructionDemolition : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("List of environmental factors associated with the demolition process. The default values are indicative only and should be replaced with project specific data where available. All factors stated per unit area.")]
+        public virtual List<IEnvironmentalFactor> EnvironmentalFactors { get; set; } = new List<IEnvironmentalFactor>() { new ClimateChangeFossilFactor { Value = 35 }, new ClimateChangeBiogenicFactor { Value = 0 }, new ClimateChangeLandUseFactor { Value = 0 }, new ClimateChangeTotalFactor { Value = 35 }, new ClimateChangeTotalNoBiogenicFactor { Value = 35 } };
+
+        [Area]
+        [Description("The area of floor that is demolished prior to construction of the new building. This is used to scale the environmental factors above.")]
+        public virtual double DemolishedFloorArea { get; set; } = 0;
+
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/WasteRate.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/WasteRate.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/LifeCycleAssessment_oM/MaterialFragments/Construction/WasteRate.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Construction/WasteRate.cs
@@ -1,0 +1,34 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.MaterialFragments.Construction
+{
+    [Description("A class defining the waste rate associated with a construction material.")]
+    public class WasteRate : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("The percentage of waste expected during construction, expressed as a value between 0 and 1.")]
+        public virtual double Rate { get; set; }
+
+        [Description("The name of the material to which the waste rate applies.")]
+        public override string Name { get; set; }
+
+        /***************************************************/
+        /**** Explicit Casting                          ****/
+        /***************************************************/
+
+        [Description("Constructs a custom waste rate given jsut the rate. Usefull to be able to provide just the rate in UIs.")]
+        public static explicit operator WasteRate(double rate)
+        {
+            return new WasteRate { Rate = rate, Name = "Custom" };
+        }
+
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/EndOfLifeRouteDistribution.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/EndOfLifeRouteDistribution.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.MaterialFragments.EndOfLife
+{
+    [Description("Class outlining the distribution between different end of life routes and scenarios for a particular material. All ratios should be between 0 and 1, and in total sum up to 1.")]
+    public class EndOfLifeRouteDistribution : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Name of the scenario or material wo which this corresponds.")]
+        public override string Name { get; set; }
+
+        [Ratio]
+        [Description("Proportion of the material that is resued. Should be a number betwen 0 and 1 where 0 means no reuse, and 1 means all is reused.")]
+        public virtual double Reuse { get; set; }
+
+        [Ratio]
+        [Description("Proportion of the material that is recycled. Should be a number betwen 0 and 1 where 0 means nothing is recyled, and 1 means all is recyled.")]
+        public virtual double Recycling { get; set; }
+
+        [Ratio]
+        [Description("Proportion of the material that is incinerated. Should be a number betwen 0 and 1 where 0 means nothing is incinerated, and 1 means all is incinerated.")]
+        public virtual double Incineration { get; set; }
+
+        [Ratio]
+        [Description("Proportion of the material that is incinerated. Should be a number betwen 0 and 1 where 0 means nothing is incinerated, and 1 means all is incinerated.")]
+        public virtual double Waste { get; set; }
+
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/FossilWasteFactor.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/FossilWasteFactor.cs
@@ -1,0 +1,25 @@
+﻿using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.MaterialFragments.EndOfLife
+{
+    [Description("Factor on the C3 to C4 module for climate change impacts.")]
+    public class FossilWasteFactor : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [ClimateChangePerQuantity]
+        [Description("Waste processing and disposal Climate change Fossil (embodied carbon) factor. Applied to the fossil factors, and also used to compute the totals. Value assumed per mass.")]
+        public virtual double C3toC4 { get; set; }
+
+        [Description("Name of the scenario or material wo which this corresponds.")]
+        public override string Name { get; set; }
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/FossilWasteFactor.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/FossilWasteFactor.cs
@@ -1,4 +1,27 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using BH.oM.Base;
 using BH.oM.Quantities.Attributes;
 using System;
 using System.Collections.Generic;

--- a/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/WasteAndDisposalFactors.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/WasteAndDisposalFactors.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using BH.oM.Quantities.Attributes;
 using System;
 using System.Collections.Generic;

--- a/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/WasteAndDisposalFactors.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/EndOfLife/WasteAndDisposalFactors.cs
@@ -1,0 +1,28 @@
+﻿using BH.oM.Base;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.MaterialFragments.EndOfLife
+{
+    [Description("WasteAndDisposalFactors defines the end of life waste processing and disposal factors to be applied to the material fragment. These factors are applied in addition to any end of life factors provided by an Environmental Product Declaration, and can be used to fill gaps where no EPD data is available. If applied this will help populate all CLimate change metrics available, with LandUseFactor being set to 0.")]
+    public class WasteAndDisposalFactors : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Factor used to compute the Fossil climate change impacts.")]
+        public virtual FossilWasteFactor FossilWasteFactor { get; set; }
+
+        [Description("Controls whether the value should override a potentially pre-existing value on the Environmental Product Declaration. If true, the factor above takes president, if false, the value above is only added if no C3 or C4 factors already have been computed.")]
+        public virtual bool OverrideEpdValue { get; set; } = false;
+
+        [Description("If true, the C3toC4 value for ClimateChangeBiogenic will be set to the negative value of A1 (if present) or A1toA3 to cancel out any benefits given in those phases. If false, this value will be assumed to be 0, and all emissions for the disposal modules related to Fossil. Works under the same premise as the OverrideEpdValue toggle.")]
+        public virtual bool CancelOutBiogenicCarbon { get; set; } = true;
+
+        /***************************************************/
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/PrecomputedModuleValues.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/PrecomputedModuleValues.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/LifeCycleAssessment_oM/MaterialFragments/PrecomputedModuleValues.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/PrecomputedModuleValues.cs
@@ -1,0 +1,22 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.LifeCycleAssessment.MaterialFragments
+{
+    [Description("Class containing a set of pre-computed values per metric type for a particular module that can be used to override existing values or fill in missing values where they dont exist. Values should be the resulting total.")]
+    public class PrecomputedModuleValues : BHoMObject
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Dictionary containing resulting values per metric type for a particular module that can be used to override existing values or fill in missing values where they dont exist. Values should be the resulting total.")]
+        public virtual Dictionary<MetricType, double> ModuleValues { get; set; } = new Dictionary<MetricType, double>();
+
+        [Description("If true, any existing values for the module will be overwritten with the pre-computed values. If false, only missing values will be filled in.")]
+        public virtual bool OverwriteExistingValues { get; set; } = true;
+    }
+}

--- a/LifeCycleAssessment_oM/MaterialFragments/Transport/SingleTransportModeImpact.cs
+++ b/LifeCycleAssessment_oM/MaterialFragments/Transport/SingleTransportModeImpact.cs
@@ -42,6 +42,8 @@ namespace BH.oM.LifeCycleAssessment.MaterialFragments.Transport
         [Description("Total distance transported with the particular vehicle.")]
         public virtual double DistanceTraveled { get; set; }
 
+        [Description("Factor applied to the resulting emission for this single mode transport. Resulting value will be multiplied by this factor. Mainly used for creating end of life routes where parts of the material will be going to different facilities.")]
+        public virtual double Factor { get; set; } = 1.0;
         /***************************************************/
 
     }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1693 

<!-- Add short description of what has been fixed -->

Adds support for computation of A5 following RICS/IStructE guidance.
A5.1 and A5.2 are handled globally, and mass ratio in relation to total mass is used to give final value for a particular material/element. This might not be 100% accurate, but assume close enough to give a indication.
These are both handled by the added GlobalEmissions config that can be inputted into the evaluation method.

A5.3 is dealt with via a provided wate rate. This is then used to compute A5.3 via grabbing resulting values from other already computed modules (A1-A4 as well as appropriate C modules).


### Test files
<!-- Link to test files to validate the proposed changes -->

[On Sharepoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/LifeCycleAssessment_oM/%231693-AddSupportForA5?csf=1&web=1&e=bTiBiZ)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->