### PR TITLE
Add a link to the initialisation assembly for toolkit initialisation settings

### DIFF
--- a/BHoM/Interface/IInitialisationSettings.cs
+++ b/BHoM/Interface/IInitialisationSettings.cs
@@ -38,7 +38,11 @@ namespace BH.oM.Base
         /**** Properties                                ****/
         /***************************************************/
 
+        [Description("Method used to intialise the toolkit. It has to be written has follows: '<Full namespace>.<Declaring type>.<Method name>'")]
         string InitialisationMethod { get; }
+
+        [Description("Name of the method containing teh initialisation assembly. Only provide the name of the assembly itself, no file path or extension.")]
+        string InitialisationAssembly { get; }
 
         /***************************************************/
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Used by 
https://github.com/BHoM/BHoM_UI/pull/531
https://github.com/BHoM/BHoMAnalytics_Toolkit/pull/95
https://github.com/BuroHappoldEngineering/BuroHappold_BHoMAnalytics_Toolkit/pull/82
https://github.com/BuroHappoldEngineering/BuroHappold_Installer/pull/462
https://github.com/BHoM/Versioning_Toolkit/pull/317
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

See https://github.com/BHoM/BHoM_UI/pull/531 for more details.

This PR can be merged prior to the BHoM_UI  once the toolkit initialisation has been tested. This will reduce the number of PR that have to be locked to this branch for ongoing testing. 


### Test files
Test that toolkit initialisation is still working correctly within the new strategy of https://github.com/BHoM/BHoM_UI/pull/531.
BHoMAnalytics toolkits seems to be the only toolkits using `ToolkitSettings` so I would test with that. 

