### PR TITLE
Added new result type and loadcase for Time History results

### DIFF
--- a/Structure_oM/Loads/TimeHistoryLoadcase.cs
+++ b/Structure_oM/Loads/TimeHistoryLoadcase.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using BH.oM.Structure.Loads;
 using System.ComponentModel;
+using BH.oM.Quantities.Attributes;
 
 namespace BH.oM.Structure.Loads
 {
@@ -34,11 +35,11 @@ namespace BH.oM.Structure.Loads
         /***************************************************/
 
         [Description("Unique name identifying the time history load case.")]
-        public virtual string Name { get; set; }
+        public override string Name { get; set; }
 
         [Description("Numerical identifier for the load case.")]
         public virtual int Number { get; set; }
-
+        
         [Time]
         [Description("Start time of the time history loadcase.")]
         public virtual double StartTime { get; set; }

--- a/Structure_oM/Loads/TimeHistoryLoadcase.cs
+++ b/Structure_oM/Loads/TimeHistoryLoadcase.cs
@@ -39,14 +39,14 @@ namespace BH.oM.Structure.Loads
         [Description("Numerical identifier for the load case.")]
         public virtual int Number { get; set; }
 
+        [Description("Start time of the time history analysis in seconds.")]
+        public virtual double StartTime { get; set; }
+
         [Description("End time of the time history analysis in seconds.")]
         public virtual double EndTime { get; set; }
 
         [Description("Time step used for the integration in seconds.")]
         public virtual double TimeStep { get; set; }
-
-        [Description("Base load case whose magnitude is scaled at each time step.")]
-        public virtual string InitialLoadCase { get; set; }
 
         /***************************************************/
     }

--- a/Structure_oM/Loads/TimeHistoryLoadcase.cs
+++ b/Structure_oM/Loads/TimeHistoryLoadcase.cs
@@ -39,7 +39,8 @@ namespace BH.oM.Structure.Loads
         [Description("Numerical identifier for the load case.")]
         public virtual int Number { get; set; }
 
-        [Description("Start time of the time history analysis in seconds.")]
+        [Time]
+        [Description("Start time of the time history loadcase.")]
         public virtual double StartTime { get; set; }
 
         [Description("End time of the time history analysis in seconds.")]

--- a/Structure_oM/Loads/TimeHistoryLoadcase.cs
+++ b/Structure_oM/Loads/TimeHistoryLoadcase.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
  *
@@ -20,30 +20,38 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
+using BH.oM.Structure.Loads;
+using System.ComponentModel;
+
 namespace BH.oM.Structure.Loads
 {
-    /***************************************************/
-    public enum LoadType
+    [Description("Defines a time history analysis case with time integration parameters.")]
+    public class TimeHistoryLoadcase : BHoMObject, ICase
     {
-        Selfweight = 0,
-        PointLoad,
-        PointDisplacement,
-        PointVelocity,
-        PointAcceleration,
-        BarPointLoad,
-        BarUniformLoad,
-        BarVaryingLoad,
-        BarTemperature,
-        AreaUniformLoad,
-        AreaVaryingLoad,
-        AreaTemperature,
-        Pressure,
-        Geometrical,
-        TransientTimeHistoryLoad,
-    }
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
 
-    /***************************************************/
+        [Description("Unique name identifying the time history load case.")]
+        public virtual string Name { get; set; }
+
+        [Description("Numerical identifier for the load case.")]
+        public virtual int Number { get; set; }
+
+        [Description("End time of the time history analysis in seconds.")]
+        public virtual double EndTime { get; set; }
+
+        [Description("Time step used for the integration in seconds.")]
+        public virtual double TimeStep { get; set; }
+
+        [Description("Base load case whose magnitude is scaled at each time step.")]
+        public virtual string InitialLoadCase { get; set; }
+
+        /***************************************************/
+    }
 }
+
 
 
 

--- a/Structure_oM/Loads/TimeHistoryLoadcase.cs
+++ b/Structure_oM/Loads/TimeHistoryLoadcase.cs
@@ -43,10 +43,11 @@ namespace BH.oM.Structure.Loads
         [Description("Start time of the time history loadcase.")]
         public virtual double StartTime { get; set; }
 
-        [Description("End time of the time history analysis in seconds.")]
+        [Time]
+        [Description("End time of the time history loadcase.")]
         public virtual double EndTime { get; set; }
 
-        [Description("Time step used for the integration in seconds.")]
+        [Description("Time step used for the loadcase.")]
         public virtual double TimeStep { get; set; }
 
         /***************************************************/

--- a/Structure_oM/Requests/Enum/LinkResultType.cs
+++ b/Structure_oM/Requests/Enum/LinkResultType.cs
@@ -20,29 +20,16 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-namespace BH.oM.Structure.Loads
-{
-    /***************************************************/
-    public enum LoadType
-    {
-        Selfweight = 0,
-        PointLoad,
-        PointDisplacement,
-        PointVelocity,
-        PointAcceleration,
-        BarPointLoad,
-        BarUniformLoad,
-        BarVaryingLoad,
-        BarTemperature,
-        AreaUniformLoad,
-        AreaVaryingLoad,
-        AreaTemperature,
-        Pressure,
-        Geometrical,
-        TransientTimeHistoryLoad,
-    }
+using System.ComponentModel;
 
-    /***************************************************/
+namespace BH.oM.Structure.Requests
+{
+    [Description("Defines the type of results that should be extracted for LinkResultRequests.")]
+    public enum LinkResultType
+    {
+        LinkDisplacement,
+        LinkForce,
+    }
 }
 
 

--- a/Structure_oM/Requests/LinkResultRequest.cs
+++ b/Structure_oM/Requests/LinkResultRequest.cs
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using System.Collections.Generic;
+
+
+namespace BH.oM.Structure.Requests
+{
+    [Description("Request for extracting Bar results from an adapter.")]
+    public class LinkResultRequest : IStructuralResultRequest
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Defines which type of results that should be extracted.")]
+        public virtual LinkResultType ResultType { get; set; } = LinkResultType.LinkDisplacement;
+
+        [Description("Defines which cases and/or combinations that results should be extracted for. Can generally be set to either Loadcase or Loadcombination objects, or identifiers matching the software. If nothing is provided, results for all cases will be assumed.")]
+        public virtual List<object> Cases { get; set; } = new List<object>();
+
+        [Description("Defines for which modes results should be extracted. Only applicable for some casetypes. If nothing is provided, results for all modes will be assumed.")]
+        public virtual List<string> Modes { get; set; } = new List<string>();
+
+        [Description("Defines which Nodes that results should be extracted for. Can generally be set to either pulled Node objects, or identifiers matching the software. If nothing is provided, results for all Nodes will be assumed.")]
+        public virtual List<object> ObjectIds { get; set; } = new List<object>();
+
+        /***************************************************/
+
+    }
+}
+
+
+
+
+
+
+

--- a/Structure_oM/Results/Link Results/LinkDisplacement.cs
+++ b/Structure_oM/Results/Link Results/LinkDisplacement.cs
@@ -1,0 +1,86 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.ComponentModel;
+using BH.oM.Quantities.Attributes;
+using BH.oM.Base;
+using BH.oM.Analytical.Results;
+
+namespace BH.oM.Structure.Results
+{
+    [Description("Resulting total displacements in global coordinates.")]
+    public class LinkDisplacement : LinkResult, IResultItem, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Length]
+        [Description("Total displacement along the global X-axis.")]
+        public virtual double UX { get; }
+
+        [Length]
+        [Description("Total displacement along the global Y-axis.")]
+        public virtual double UY { get; }
+
+        [Length]
+        [Description("Total displacement along the global Z-axis.")]
+        public virtual double UZ { get; }
+
+        [Angle]
+        [Description("Total rotation about the global X-axis.")]
+        public virtual double RX { get; }
+
+        [Angle]
+        [Description("Total rotation about the global Y-axis.")]
+        public virtual double RY { get; }
+
+        [Angle]
+        [Description("Total rotation about the global Z-axis.")]
+        public virtual double RZ { get; }
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public LinkDisplacement(IComparable objectId, IComparable resultCase, int modeNumber, double timeStep, double ux, double uy, double uz, double rx, double ry, double rz)
+            : base(objectId, resultCase, modeNumber, timeStep)
+        {
+            UX = ux;
+            UY = uy;
+            UZ = uz;
+            RX = rx;
+            RY = ry;
+            RZ = rz;
+        }
+
+        /***************************************************/
+    }
+}
+
+
+
+
+
+
+

--- a/Structure_oM/Results/Link Results/LinkForce.cs
+++ b/Structure_oM/Results/Link Results/LinkForce.cs
@@ -28,7 +28,7 @@ using BH.oM.Base;
 
 namespace BH.oM.Structure.Results
 {
-    [Description("Resulting section forces in local coordinates along the bar.")]
+    [Description("Resulting forces in local coordinates along the general link.")]
     public class LinkForce : LinkResult, IResultItem, IImmutable
     {
         /***************************************************/

--- a/Structure_oM/Results/Link Results/LinkForce.cs
+++ b/Structure_oM/Results/Link Results/LinkForce.cs
@@ -36,7 +36,7 @@ namespace BH.oM.Structure.Results
         /***************************************************/
 
         [Force]
-        [Description("Axial force along the local x-axis. Positive for tension, negative for compression.")]
+        [Description("Axial force along the local x-axis.")]
         public virtual double FX { get; }
 
         [Force]

--- a/Structure_oM/Results/Link Results/LinkForce.cs
+++ b/Structure_oM/Results/Link Results/LinkForce.cs
@@ -1,0 +1,86 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using BH.oM.Quantities.Attributes;
+using System;
+using BH.oM.Analytical.Results;
+using BH.oM.Base;
+
+namespace BH.oM.Structure.Results
+{
+    [Description("Resulting section forces in local coordinates along the bar.")]
+    public class LinkForce : LinkResult, IResultItem, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Force]
+        [Description("Axial force along the local x-axis. Positive for tension, negative for compression.")]
+        public virtual double FX { get; }
+
+        [Force]
+        [Description("Shear force along the local y-axis. Generally minor axis shear force.")]
+        public virtual double FY { get; }
+
+        [Force]
+        [Description("Shear force along the local z-axis. Generally major axis shear force.")]
+        public virtual double FZ { get; }
+
+        [Moment]
+        [Description("Torsional moment.")]
+        public virtual double MX { get; }
+
+        [Moment]
+        [Description("Bending moment about the local y-axis. Generally major axis bending moment.")]
+        public virtual double MY { get; }
+
+        [Moment]
+        [Description("Bending moment about the local z-axis. Generally minor axis bending moment.")]
+        public virtual double MZ { get; }
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public LinkForce(IComparable objectId, IComparable resultCase, int modeNumber, double timeStep, double fx, double fy, double fz, double mx, double my, double mz)
+            : base(objectId, resultCase, modeNumber, timeStep)
+        {
+            FX = fx;
+            FY = fy;
+            FZ = fz;
+            MX = mx;
+            MY = my;
+            MZ = mz;
+        }
+
+        /***************************************************/
+    }
+}
+
+
+
+
+
+
+

--- a/Structure_oM/Results/Link Results/LinkResult.cs
+++ b/Structure_oM/Results/Link Results/LinkResult.cs
@@ -35,7 +35,7 @@ namespace BH.oM.Structure.Results
         /**** Properties                                ****/
         /***************************************************/
 
-        [Description("Id of the bar that this result belongs to. When extracted from an analysis package, the object id will match the format and value used in that particular package.")]
+        [Description("Id of the general link that this result belongs to. When extracted from an analysis package, the object id will match the format and value used in that particular package.")]
         public virtual IComparable ObjectId { get; }
 
         [Description("Identifier for the Loadcase or LoadCombination that the result belongs to. Is generally name or number of the loadcase, depending on the analysis package.")]

--- a/Structure_oM/Results/Link Results/LinkResult.cs
+++ b/Structure_oM/Results/Link Results/LinkResult.cs
@@ -1,0 +1,106 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using BH.oM.Base;
+using BH.oM.Analytical.Results;
+using System.ComponentModel;
+
+
+namespace BH.oM.Structure.Results
+{
+    [Description("Base class for all bar result classes. Stores all identifier information and how to sort the results in a collection.")]
+    public abstract class LinkResult : IStructuralResult, IImmutable
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Id of the bar that this result belongs to. When extracted from an analysis package, the object id will match the format and value used in that particular package.")]
+        public virtual IComparable ObjectId { get; }
+
+        [Description("Identifier for the Loadcase or LoadCombination that the result belongs to. Is generally name or number of the loadcase, depending on the analysis package.")]
+        public virtual IComparable ResultCase { get; }
+
+        [Description("Positive index, starting at one. Only set for cases with modal outputs such as dynamic cases.")]
+        public virtual int ModeNumber { get; }
+
+        [Description("Time step for time history results.")]
+        public virtual double TimeStep { get; }
+
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public LinkResult(IComparable objectId, IComparable resultCase, int modeNumber, double timeStep)
+        {
+            ObjectId = objectId;
+            ResultCase = resultCase;
+            ModeNumber = modeNumber;
+            TimeStep = timeStep;
+        }
+
+        /***************************************************/
+        /**** IComparable Interface                     ****/
+        /***************************************************/
+
+        [Description("Controls how this result is sorted in relation to other results. Sorts with the following priority: Type, ObjectId, ResultCase, TimeStep.")]
+        public int CompareTo(IResult other)
+        {
+            LinkResult otherRes = other as LinkResult;
+
+            if (otherRes == null)
+                return this.GetType().Name.CompareTo(other.GetType().Name);
+
+            int n = this.ObjectId.CompareTo(otherRes.ObjectId);
+            if (n == 0)
+            {
+                int l = this.ResultCase.CompareTo(otherRes.ResultCase);
+                if (l == 0)
+                {
+                    int m = this.ModeNumber.CompareTo(otherRes.ModeNumber);
+                    return m == 0 ? this.TimeStep.CompareTo(otherRes.TimeStep) : m;
+                }
+                else
+                {
+                    return l;
+                }
+            }
+            else
+            {
+                return n;
+            }
+
+        }
+
+        /***************************************************/
+    }
+}
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1702 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Added new `LinkResultRequest` type, allowing the user to provide a range for result extraction (`LinkDeformation` or `LinkForce`)
- Added new `LinkResult` object;
- Added `LinkForce` and `LinkDeformation` objects;
- Added new `TimeHistoryLoadcase` class;

### Additional comments
<!-- As required -->