### PR TITLE
Code-compliance fixes

### DIFF
--- a/Acoustic_oM/Elements/Panel.cs
+++ b/Acoustic_oM/Elements/Panel.cs
@@ -36,7 +36,7 @@ namespace BH.oM.Acoustic
 
         public virtual int PanelID { get; set; } = 0;
 
-        public Dictionary<Frequency, double> R { get; set; } = new Dictionary<Frequency, double>
+        public virtual Dictionary<Frequency, double> R { get; set; } = new Dictionary<Frequency, double>
         {
             { Frequency.Hz63, 1 }, { Frequency.Hz125, 1 }, { Frequency.Hz250, 1 }, { Frequency.Hz500, 1 }, { Frequency.Hz1000, 1 },
             { Frequency.Hz2000, 1 }, { Frequency.Hz4000, 1 }, { Frequency.Hz8000, 1 }, { Frequency.Hz16000, 1 },

--- a/BHoM/BHoMGroup.cs
+++ b/BHoM/BHoMGroup.cs
@@ -30,7 +30,7 @@ namespace BH.oM.Base
         /**** Properties                                ****/
         /***************************************************/
 
-        public List<T> Elements { get; set; } = new List<T>();
+        public virtual List<T> Elements { get; set; } = new List<T>();
 
 
         /***************************************************/

--- a/BHoM/Enumeration.cs
+++ b/BHoM/Enumeration.cs
@@ -35,17 +35,7 @@ namespace BH.oM.Base
 
         public virtual string Value { get; private set; }
 
-        public virtual string Description
-        {
-            get
-            {
-                return m_Description.Length > 0 ? m_Description : Value;
-            }
-            private set
-            {
-                m_Description = value;
-            }
-        }
+        public virtual string Description { get; private set; }
 
 
         /***************************************************/
@@ -55,7 +45,7 @@ namespace BH.oM.Base
         protected Enumeration(string value, string description = "")
         {
             Value = value;
-            m_Description = description;
+            Description = description.Length > 0 ? description : value;
         }
 
 
@@ -93,13 +83,6 @@ namespace BH.oM.Base
         {
             return Value.CompareTo(other?.Value);
         }
-
-
-        /***************************************************/
-        /**** Private Fields                            ****/
-        /***************************************************/
-
-        private string m_Description = "";
 
 
         /***************************************************/

--- a/Data_oM/Collections/Domain.cs
+++ b/Data_oM/Collections/Domain.cs
@@ -34,10 +34,10 @@ namespace BH.oM.Data.Collections
         /***************************************************/
 
         [Description("The lowest bound of the domain.")]
-        public double Min { get; }
+        public virtual double Min { get; }
 
         [Description("The highest bound of the domain.")]
-        public double Max { get; }
+        public virtual double Max { get; }
 
         /***************************************************/
 

--- a/Data_oM/Collections/DomainBox.cs
+++ b/Data_oM/Collections/DomainBox.cs
@@ -34,7 +34,7 @@ namespace BH.oM.Data.Collections
         /***************************************************/
 
         [Description("Array containing the domain for each dimension.")]
-        public Domain[] Domains { get; set; } = null;
+        public virtual Domain[] Domains { get; set; } = null;
 
         /***************************************************/
 

--- a/Diffing_oM/AECDeltas/DeltaPayload.cs
+++ b/Diffing_oM/AECDeltas/DeltaPayload.cs
@@ -38,17 +38,17 @@ namespace BH.oM.AECDeltas
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
-        public Guid StreamID { get; }
+        public virtual Guid StreamID { get; }
 
-        public Dictionary<string, object> Diff { get; }
+        public virtual Dictionary<string, object> Diff { get; }
 
-        public string RevisionFrom { get; }
-        public string RevisionTo { get; }
+        public virtual string RevisionFrom { get; }
+        public virtual string RevisionTo { get; }
 
-        public long Timestamp { get; }
-        public string Signature { get; }
-        public string Sender { get; }
-        public string Comment { get; }
+        public virtual long Timestamp { get; }
+        public virtual string Signature { get; }
+        public virtual string Sender { get; }
+        public virtual string Comment { get; }
 
 
         /***************************************************/

--- a/Diffing_oM/StreamPointer.cs
+++ b/Diffing_oM/StreamPointer.cs
@@ -38,10 +38,10 @@ namespace BH.oM.Diffing
         /**** Properties                                ****/
         /***************************************************/
 
-        public Guid StreamID { get; }
-        public string StreamName { get; }
-        public string Description { get; }
-        public long Timestamp { get; }
+        public virtual Guid StreamID { get; }
+        public virtual string StreamName { get; }
+        public virtual string Description { get; }
+        public virtual long Timestamp { get; }
 
         /***************************************************/
         /**** Constructor                               ****/

--- a/Graphics_oM/Colours/ColourFragment.cs
+++ b/Graphics_oM/Colours/ColourFragment.cs
@@ -35,7 +35,7 @@ namespace BH.oM.Graphics
         /****            Public Properties              ****/
         /***************************************************/
 
-        public Color Colour { get; set; }
+        public virtual Color Colour { get; set; }
 
         /***************************************************/
     }

--- a/Verification_oM/Reporting/FormulaConditionReportingConfig.cs
+++ b/Verification_oM/Reporting/FormulaConditionReportingConfig.cs
@@ -33,7 +33,7 @@ namespace BH.oM.Verification.Reporting
         /***************************************************/
 
         [Description("Dictionary of reporting configs (values) bound to the components, which values they are meant to format (keys).")]
-        public Dictionary<string, IValueConditionReportingConfig> ComponentConfigs { get; set; } = new Dictionary<string, IValueConditionReportingConfig>();
+        public virtual Dictionary<string, IValueConditionReportingConfig> ComponentConfigs { get; set; } = new Dictionary<string, IValueConditionReportingConfig>();
 
         /***************************************************/
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1713 
Fix pre-existing `IsVirtualProperty` and `PropertyAccessorsHaveNoBody` compliance violations
exposed by the 9.1 copyright header sweep.

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Internal only installer](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/%231714-Fix-Code-Compliance/BHoM-%231713-Fix-Code-Compliance.msi?csf=1&web=1&e=joCN1j)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Acoustic_oM/Elements/Panel`: `R` property marked `virtual`
- `BHoM/BHoMGroup`: `Elements` property marked `virtual`
- `BHoM/Enumeration`: `Description` converted to auto-property; fallback logic moved to constructor; `m_Description` field removed
- `Data_oM/Collections/Domain`: `Min`, `Max` properties marked `virtual`
- `Data_oM/Collections/DomainBox`: `Domains` property marked `virtual`
- `Diffing_oM/AECDeltas/DeltaPayload`: all properties marked `virtual`
- `Diffing_oM/StreamPointer`: all properties marked `virtual`
- `Graphics_oM/Colours/ColourFragment`: `Colour` property marked `virtual`
- `Verification_oM/Reporting/FormulaConditionReportingConfig`: `ComponentConfigs` property marked `virtual`


### Additional comments
<!-- As required -->
These violations are pre-existing and not caused by recent work. The compliance check only scans
files in the PR diff the annual copyright header update touched all of these files, bringing
them into scope for the first time and surfacing the hidden violations.