### PR TITLE
Physical_oM: Add MaterialClassification class

### DIFF
--- a/Physical_oM/Materials/MaterialClassification.cs
+++ b/Physical_oM/Materials/MaterialClassification.cs
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Physical.Materials
+{
+    [Description("Represents a generic material by its category, type, grade, and constituent. This classification can be used to identify and group materials for various purposes, such as material selection, specification, and analysis.\n" +
+                 "The classification can be put on a phsyical Material as a IMaterialProeprties or on a MaterialFragment as a IFragment.")]
+    public class MaterialClassification : BHoMObject, IMaterialProperties, IFragment
+    {
+        [Description("The category of the material, e.g., 'Concrete', 'Steel', 'Wood', etc.")]
+        public virtual string Category { get; set; } = "";
+
+        [Description("The type of the material, e.g., 'Reinforced', 'Prestressed', etc.")]
+        public virtual string Type { get; set; } = "";
+
+        [Description("The grade of the material, e.g., 'C30/37', 'S420', 'F175', etc.")]
+        public virtual string Grade { get; set; } = "";
+
+        [Description("The constituent of the material, e.g., Fly Ash, GGBS, etc.")]
+        public virtual string Constituent { get; set; } = "";
+    }
+
+}

--- a/Physical_oM/Versioning_93.json
+++ b/Physical_oM/Versioning_93.json
@@ -1,0 +1,26 @@
+{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+        "BH.oM.StructureEmbodiedCarbon.Elements.MaterialClassification": "BH.oM.Physical.Materials.MaterialClassification"
+    },
+    "ToOld": {
+        "BH.oM.Physical.Materials.MaterialClassification": "BH.oM.StructureEmbodiedCarbon.Elements.MaterialClassification"
+    }
+  },
+  "Property": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "MessageForDeleted": {
+  },
+  "MessageForNoUpgrade": {
+  }
+}


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1725


<!-- Add short description of what has been fixed -->

Add MaterialClassification class
Migrated over from other toolkit
Namespace adjusted
IFragment implemented to allowed to be attached to IMaterialProperties as well as physical materials

### Test files
<!-- Link to test files to validate the proposed changes -->

[On Sharepoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Physical_oM/%231731-AddMaterialClassificationClass?d=w7332c3a1ecf74ccabfa37c2b556b7a0b&csf=1&web=1&e=c6NdYJ)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

Initially intended to put in Matter_oM, but various dependency challenges made it impossible. Also do not mind this living next to the other materials in the phsyical namespace.

If matter-related classes starts growing a bit more, might be scope to migrate some of the classes like this, as well as interfaces like the IMaterialProperties over to Matter_oM, but out of scope for this PR.