### PR TITLE
Structure_oM: Add ConnectionAllowance fragment

### DIFF
--- a/Structure_oM/Fragments/ConnectionAllowance.cs
+++ b/Structure_oM/Fragments/ConnectionAllowance.cs
@@ -30,7 +30,7 @@ using BH.oM.Structure.Elements;
 
 namespace BH.oM.Structure.Fragments
 {
-    [Description("The ConnectionAllowance of an element. Used when evaluating takeoffs to .")]
+    [Description("The connection allowance of an element. Used when evaluating takeoffs to account for additional mass due to connections of the element.")]
     public class ConnectionAllowance : IFragment
     {
         [Ratio]
@@ -40,8 +40,8 @@ namespace BH.oM.Structure.Fragments
         [Description("Optional material to be used for the connection. If null, the material of the element will be assumed.")]
         public virtual IMaterialFragment Material { get; set; } = null;
 
-        [Description("Optional name for the connection allowance. Will be assigned as the name of the takeoff materials. If left empty, the name of the Material (or name of the material of the element) will be used instead.\n" +
-                     "Can be useful if one wants to differentiate between connection and element contributions in the takeoff.")]
+        [Description("Optional name for the connection allowance. It will be assigned as the name of the takeoff material. If left empty, the name of the material (or the name of the material of the element) will be used instead.\n" +
+                     "This can be useful if one wants to differentiate between connection and element contributions in the takeoff.")]
         public virtual string Name { get; set; } = "";
     }
 }

--- a/Structure_oM/Fragments/ConnectionAllowance.cs
+++ b/Structure_oM/Fragments/ConnectionAllowance.cs
@@ -34,7 +34,7 @@ namespace BH.oM.Structure.Fragments
     public class ConnectionAllowance : IFragment
     {
         [Ratio]
-        [Description("Additional connection allowance expressed as a ratio of the mass of the element. E.g. put a value of 0.1 means a connection allowance equal to 10% of the mass of the element to which this fragment is applied.")]
+        [Description("Additional connection allowance expressed as a ratio of the mass of the element. For example, a value of 0.1 means a connection allowance equal to 10% of the mass of the element to which this fragment is applied.")]
         public virtual double Allowance { get; set; } = 0;
 
         [Description("Optional material to be used for the connection. If null, the material of the element will be assumed.")]

--- a/Structure_oM/Fragments/ConnectionAllowance.cs
+++ b/Structure_oM/Fragments/ConnectionAllowance.cs
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using BH.oM.Quantities.Attributes;
+using BH.oM.Structure.MaterialFragments;
+using System.ComponentModel;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Structure.Elements;
+
+namespace BH.oM.Structure.Fragments
+{
+    [Description("The ConnectionAllowance of an element. Used when evaluating takeoffs to .")]
+    public class ConnectionAllowance : IFragment
+    {
+        [Ratio]
+        [Description("Additional connection allowance expressed as a ratio of the mass of the element. E.g. put a value of 0.1 means a connection allowance equal to 10% of the mass of the element to which this fragment is applied.")]
+        public virtual double Allowance { get; set; } = 0;
+
+        [Description("Optional material to be used for the connection. If null, the material of the element will be assumed.")]
+        public virtual IMaterialFragment Material { get; set; } = null;
+
+        [Description("Optional name for the connection allowance. Will be assigned as the name of the takeoff materials. If left empty, the name of the Material (or name of the material of the element) will be used instead.\n" +
+                     "Can be useful if one wants to differentiate between connection and element contributions in the takeoff.")]
+        public virtual string Name { get; set; } = "";
+    }
+}
+
+
+
+
+
+


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1728 

<!-- Add short description of what has been fixed -->

Add fragment to give an additional allowance to be used in material takeoffs.

Allows engineers to writeup the takeoff as a percentage of mass of the element to which the fragment is attached.


### Test files
<!-- Link to test files to validate the proposed changes -->

[On sharepoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Structure_oM/%231732-AddConnectionAllowanceFragment?d=wa4a930735193470eb68f3d9375fd428d&csf=1&web=1&e=2FUob2)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->